### PR TITLE
gcc-runtime: Remove libgfortran data from receipe

### DIFF
--- a/meta/recipes-devtools/gcc/gcc-runtime.inc
+++ b/meta/recipes-devtools/gcc/gcc-runtime.inc
@@ -76,9 +76,6 @@ PACKAGES = "\
     libssp \
     libssp-dev \
     libssp-staticdev \
-    libgfortran \
-    libgfortran-dev \
-    libgfortran-staticdev \
     libmudflap \
     libmudflap-dev \
     libmudflap-staticdev \
@@ -130,18 +127,6 @@ FILES_libssp-dev = "\
     ${libdir}/gcc/${TARGET_SYS}/${BINV}/include/ssp \
 "
 FILES_libssp-staticdev = "${libdir}/libssp*.a"
-
-FILES_libgfortran = "${libdir}/libgfortran.so.*"
-FILES_libgfortran-dev = "\
-    ${libdir}/libgfortran*.so \
-    ${libdir}/libgfortran.spec \
-    ${libdir}/libgfortran.la \
-    ${libdir}/gcc/${TARGET_SYS}/${BINV}/libgfortranbegin.* \
-    ${libdir}/gcc/${TARGET_SYS}/${BINV}/libcaf_single* \
-"
-FILES_libgfortran-staticdev = "${libdir}/libgfortran.a"
-
-INSANE_SKIP_${MLPREFIX}libgfortran-dev = "staticdev"
 
 FILES_libquadmath = "${libdir}/libquadmath*.so.*"
 FILES_libquadmath-dev = "\


### PR DESCRIPTION
Bring in de2aa7a56790581406f219339c9022638cd47494 from upstream to allow compilation of gfortran to work.

If anyone else wants to compile libgfortran, you also need to set the following in local.conf:

```
FORTRAN_forcevariable = ",fortran"
RUNTIMETARGET_append_pn-gcc-runtime = " libquadmath"

PREFERRED_VERSION_libgfortran="4.8.2"
PREFERRED_VERSION_nativesdk_libgfortran="4.8.2"
```
