### PR TITLE
Tweaks for building and installing the 'next' kernel from package feeds

### DIFF
--- a/meta/classes/kernel-module-split.bbclass
+++ b/meta/classes/kernel-module-split.bbclass
@@ -103,6 +103,7 @@ python split_kernel_module_packages () {
         files = d.getVar('FILES_%s' % pkg)
         files = "%s /etc/modules-load.d/%s.conf /etc/modprobe.d/%s.conf" % (files, basename, basename)
         d.setVar('FILES_%s' % pkg, files)
+        d.setVar('CONFFILES_%s' % pkg, files)
 
         if "description" in vals:
             old_desc = d.getVar('DESCRIPTION_' + pkg) or ""

--- a/meta/classes/kernel.bbclass
+++ b/meta/classes/kernel.bbclass
@@ -489,7 +489,7 @@ sysroot_stage_all () {
 	:
 }
 
-KERNEL_CONFIG_COMMAND ?= "oe_runmake_call -C ${S} CC="${KERNEL_CC}" O=${B} oldnoconfig"
+KERNEL_CONFIG_COMMAND ?= "oe_runmake_call -C ${S} CC="${KERNEL_CC}" O=${B} olddefconfig || oe_runmake -C ${S} O=${B} CC="${KERNEL_CC}" oldnoconfig"
 
 python check_oldest_kernel() {
     oldest_kernel = d.getVar('OLDEST_KERNEL')


### PR DESCRIPTION
These small tweaks complement the meta-nilrt pull request: https://github.com/ni/meta-nilrt/pull/28

- Cherry-picked commit 2c88137 ("kernel: use olddefconfig as the primary target for KERNEL_CONFIG_COMMAND") from Dunfell fixes a build issue encountered in sumo with newer kernels.

- Commit 3403e10 ("kernel-module-split: Identify kernel modconf files as configuration files") fixes and existing issue where the kernel module conf files are not listed as 'configuration files' which causes problems with side by side kernel installs.