### PR TITLE
package.bbclass: fix addtask directive warning

### DIFF
--- a/meta/classes/package.bbclass
+++ b/meta/classes/package.bbclass
@@ -2344,7 +2344,8 @@ def mapping_rename_hook(d):
     runtime_mapping_rename("RRECOMMENDS", pkg, d)
     runtime_mapping_rename("RSUGGESTS", pkg, d)
 
-addtask do_install_source after do_fetch after do_install before do_package
+addtask do_install_source after do_fetch before do_package
+addtask do_install_source after do_install before do_package
 
 python do_install_source () {
     oe.package.do_install_source(d)


### PR DESCRIPTION
Bitbake throws an annoying warning if a single addtask directive
declares more than one 'after' or 'before' keywords. It looks like this:

WARNING: addtask contained multiple 'after' keywords, only one is supported

Split the `addtask` directive for `do_install_source` into two lines to
avoid angering the sanity checker.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

**Testing**
Reparsed the bitbake environment with this change and verified that it parsed correctly and that the warning is gone. Checked the environment and verified that the `do_install_source` task still has dependencies on both `do_fetch` and `do_install`.

```
_task_deps="{'tasks': <snip> 'do_install_source': ['do_fetch', 'do_install'], <snip>
```