### PR TITLE
Replace globbing in file:// with list of files.

### DIFF
--- a/meta/recipes-connectivity/connman/connman-gnome_0.7.bb
+++ b/meta/recipes-connectivity/connman/connman-gnome_0.7.bb
@@ -13,7 +13,7 @@ SRCREV = "cf3c325b23dae843c5499a113591cfbc98acb143"
 SRC_URI = "git://github.com/connectivity/connman-gnome.git \
            file://0001-Removed-icon-from-connman-gnome-about-applet.patch \
            file://null_check_for_ipv4_config.patch \
-           file://images/* \
+           file://images/ \
            file://connman-gnome-fix-dbus-interface-name.patch \
            file://0001-Port-to-Gtk3.patch \
           "

--- a/meta/recipes-sato/matchbox-desktop/matchbox-desktop_2.2.bb
+++ b/meta/recipes-sato/matchbox-desktop/matchbox-desktop_2.2.bb
@@ -13,7 +13,7 @@ SECTION = "x11/wm"
 # SRCREV tagged 2.2
 SRCREV = "6bc67d09da4147e5552fe30011a05a2c59d2f777"
 SRC_URI = "git://git.yoctoproject.org/${BPN}-2 \
-           file://vfolders/* \
+           file://vfolders/ \
            "
 
 EXTRA_OECONF = "--enable-startup-notification --with-dbus"


### PR DESCRIPTION
The upstream bitbake parser no longer supports globbing in file://
urls. Replace those instances with the complete list of files to be
included.

Built locally.