### PR TITLE
opkg-utils: Update from 0.4.2 to 0.4.3

### DIFF
--- a/meta/recipes-devtools/opkg-utils/opkg-utils_0.4.3.bb
+++ b/meta/recipes-devtools/opkg-utils/opkg-utils_0.4.3.bb
@@ -11,8 +11,8 @@ SRC_URI = "http://git.yoctoproject.org/cgit/cgit.cgi/${BPN}/snapshot/${BPN}-${PV
 "
 UPSTREAM_CHECK_URI = "http://git.yoctoproject.org/cgit/cgit.cgi/opkg-utils/refs/"
 
-SRC_URI[md5sum] = "cc210650644fcb9bba06ad5ec95a63ec"
-SRC_URI[sha256sum] = "5929ad87d541789e0b82d626db01a1201ac48df6f49f2262fcfb86cf815e5d6c"
+SRC_URI[md5sum] = "7bbadb3c381f3ea935b21d3bb8cc4671"
+SRC_URI[sha256sum] = "046517600fb0aed6c4645edefe02281f4fa2f1c02f71596152d93172452c0b01"
 
 TARGET_CC_ARCH += "${LDFLAGS}"
 


### PR DESCRIPTION
Version 0.4.3 is the first to include the `opkg-feed` utility.
This uses the same SRC_URI [as done in the dunfell branch](https://github.com/ni/openembedded-core/commit/810826b644f93ad3923647e387ce849c3e71bb1b#diff-6d878eba913c44ffbdf44dca0b3e6a0cbd5e5d5badd72e86e2f5ae105b81b31a).

FYI @ni/rtos 