### PR TITLE
opkg-utils: split package so scripts can be installed individually

### DIFF
--- a/meta/recipes-devtools/opkg-utils/opkg-utils_0.4.3.bb
+++ b/meta/recipes-devtools/opkg-utils/opkg-utils_0.4.3.bb
@@ -1,4 +1,6 @@
 SUMMARY = "Additional utilities for the opkg package manager"
+SUMMARY_opkg-utils-shell-tools = "Additional utilities for the opkg package manager (shell scripts)"
+SUMMARY_opkg-utils-python-tools = "Additional utilities for the opkg package manager (python scripts)"
 SUMMARY_update-alternatives-opkg = "Utility for managing the alternatives system"
 SECTION = "base"
 HOMEPAGE = "http://git.yoctoproject.org/cgit/cgit.cgi/opkg-utils"
@@ -16,7 +18,13 @@ SRC_URI[sha256sum] = "046517600fb0aed6c4645edefe02281f4fa2f1c02f71596152d9317245
 
 TARGET_CC_ARCH += "${LDFLAGS}"
 
-RDEPENDS_${PN} += "bash"
+SUBPACKAGES = "opkg-utils-shell-tools ${@bb.utils.contains('PACKAGECONFIG', 'python', 'opkg-utils-python-tools', '', d)}"
+
+PACKAGES =+ "${SUBPACKAGES}"
+
+# main package is a metapackage that depends on all the subpackages
+ALLOW_EMPTY_${PN} = "1"
+RDEPENDS_${PN} += "${SUBPACKAGES}"
 
 # For native builds we use the host Python
 PYTHONRDEPS = "python3 python3-shell python3-io python3-math python3-crypt python3-logging python3-fcntl python3-pickle python3-compression python3-stringold"
@@ -26,15 +34,42 @@ PACKAGECONFIG = "python update-alternatives"
 PACKAGECONFIG[python] = ",,,${PYTHONRDEPS}"
 PACKAGECONFIG[update-alternatives] = ",,,"
 
+FILES_opkg-utils-shell-tools = "\
+    ${bindir}/opkg-build \
+    ${mandir}/man1/opkg-build.1 \
+    ${bindir}/opkg-buildpackage \
+    ${bindir}/opkg-diff \
+    ${bindir}/opkg-extract-file \
+    ${bindir}/opkg-feed \
+    ${bindir}/opkg-unbuild \
+"
+
+FILES_opkg-utils-python-tools = "\
+    ${bindir}/opkg-compare-indexes \
+    ${bindir}/opkg-graph-deps \
+    ${bindir}/opkg-list-fields \
+    ${bindir}/opkg-make-index \
+    ${bindir}/opkg-show-deps \
+    ${bindir}/opkg-update-index \
+    ${bindir}/arfile.py \
+    ${bindir}/opkg.py \
+"
+
+RDEPENDS_opkg-utils-shell-tools += "bash"
+
+# python tools depend on shell tools because opkg-compare-indexes needs opkg-diff
+RDEPENDS_opkg-utils-python-tools += "${PYTHONRDEPS} opkg-utils-shell-tools"
+
+RRECOMMENDS_${PN}_class-native = ""
+RRECOMMENDS_${PN}_class-nativesdk = ""
+RDEPENDS_${PN}_class-native = ""
+RDEPENDS_${PN}_class-nativesdk = ""
+
 do_install() {
 	oe_runmake PREFIX=${prefix} DESTDIR=${D} install
 	if ! ${@bb.utils.contains('PACKAGECONFIG', 'update-alternatives', 'true', 'false', d)}; then
 		rm -f "${D}${bindir}/update-alternatives"
 	fi
-
-    if ! ${@bb.utils.contains('PACKAGECONFIG', 'python', 'true', 'false', d)}; then
-        grep -lZ "/usr/bin/env.*python" ${D}${bindir}/* | xargs -0 rm
-    fi
 }
 
 do_install_append_class-target() {
@@ -45,7 +80,7 @@ do_install_append_class-target() {
 
 # These are empty and will pull python3-dev into images where it wouldn't
 # have been otherwise, so don't generate them.
-PACKAGES_remove = "${PN}-dev ${PN}-staticdev"
+PACKAGES_remove = "${PN}-dbg ${PN}-dev ${PN}-staticdev"
 
 PACKAGES =+ "update-alternatives-opkg"
 FILES_update-alternatives-opkg = "${bindir}/update-alternatives"


### PR DESCRIPTION
Not all scripts in opkg-utils require python3 as a dependency; some of
them are implemented in shell and only require that. This commit splits
the opkg-utils package into several subpackages so that individual
scripts can be included without requiring all scripts, particularly the
ones that require a python3 runtime.

For compatibility, the opkg-utils package itself continues to exist as
a metapackage that depends on all its subpackages so that installing
"opkg-utils" would install all the things it would before.

Signed-off-by: Brandon Streiff <brandon.streiff@ni.com>