### PR TITLE
kernel-devsrc: remove python3 dependency

### DIFF
--- a/meta/recipes-kernel/linux/kernel-devsrc.inc
+++ b/meta/recipes-kernel/linux/kernel-devsrc.inc
@@ -271,7 +271,7 @@ do_install[lockfiles] = "${TMPDIR}/kernel-scripts.lock"
 FILES_${PN} = "${KERNEL_BUILD_ROOT} ${KERNEL_SRC_PATH}"
 FILES_${PN}-dbg += "${KERNEL_BUILD_ROOT}*/build/scripts/*/.debug/*"
 
-RDEPENDS_${PN} = "bc python3 flex bison ${TCLIBC}-utils"
+RDEPENDS_${PN} = "bc flex bison ${TCLIBC}-utils"
 # 4.15+ needs these next two RDEPENDS
 RDEPENDS_${PN} += "openssl-dev util-linux"
 # and x86 needs a bit more for 4.15+


### PR DESCRIPTION
The python3 dependency in kernel-devsrc pulls in a significant number of
python packages and has a disproportionate disk impact which affects
installation an small disk targets.

The dependency is used by a handful of (mostly debug) python scripts:
  /lib/modules/*/build/scripts/gdb/*
  /lib/modules/*/build/scripts/tracing/*.py
  /lib/modules/*/build/scripts/checkkconfigsymbols.py

These scripts are not necessary for dkms operations i.e. the main reason we
include kernel-devsrc as a dependency on NILRT.

Remove this dependency to conserve disk space. Additional python support
can be installed from package feeds by users who desire to use these
scripts at run-time.

Upstream-Status: Inappropriate [NILRT Specific]
Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>