### PR TITLE
kernel-devsrc: task-depend upon kernel:do_shared_workdir

### DIFF
--- a/meta/recipes-kernel/linux/kernel-devsrc.inc
+++ b/meta/recipes-kernel/linux/kernel-devsrc.inc
@@ -15,9 +15,9 @@ inherit module-base
 # We need the kernel to be staged (unpacked, patched and configured) before
 # we can grab the source and make the source package. We also need the bits from
 # ${B} not to change while we install, so virtual/kernel must finish do_compile.
-#do_install[depends] += "${KERNEL_DEPENDENCY}:do_shared_workdir"
+do_install[depends] += "${KERNEL_DEPENDENCY}:do_shared_workdir"
 # Need the source, not just the output of populate_sysroot
-#do_install[depends] += "${KERNEL_DEPENDENCY}:do_install"
+do_install[depends] += "${KERNEL_DEPENDENCY}:do_install"
 
 do_configure[depends] = "${KERNEL_DEPENDENCY}:do_deploy"
 


### PR DESCRIPTION
A recent build of the NIOE/8.8 pipeline failed in the kernel-devsrc do_install task. The reason being that a change (#22) went into `kernel-devsrc`, which provoked OE to rebuild the recipe. However, nothing had changed the kernel recipes, so they could be restored from sstate. The sstate objects for the kernel do not include the `work-shared/x64/kernel-source` directory needed by -devsrc.

The solution here is to have the `kernel-devsrc:do_install` depend on the `kernel:do_shared_workdir` task. This is (experimentally) enough to provoke OE to rebuild the kernel and kernel-devsrc together.

# Testing
Without this change, the build machine would not complete the `do_install` task. With this change, OE automatically rebuilt the kernel recipe, populated the work-shared directory, and completed both the kernel and kernel-devsrc recipes.

@ni/rtos 