### PR TITLE
Revert "bitbake.conf: drop pod2man from hosttools"

### DIFF
--- a/meta/conf/bitbake.conf
+++ b/meta/conf/bitbake.conf
@@ -486,7 +486,7 @@ HOSTTOOLS += " \
     cpp cut date dd diff diffstat dirname du echo egrep env expand expr false \
     fgrep file find flock g++ gawk gcc getconf getopt git grep gunzip gzip \
     head hostname id install ld ldd ln ls make makeinfo md5sum mkdir mknod \
-    mktemp mv nm objcopy objdump od patch perl pr printf pwd python python2 \
+    mktemp mv nm objcopy objdump od patch perl pod2man pr printf pwd python python2 \
     python2.7 python3 ranlib readelf readlink rm rmdir rpcgen sed sh sha256sum \
     sleep sort split stat strings strip tail tar tee test touch tr true uname \
     uniq wc wget which xargs \


### PR DESCRIPTION
This reverts commit c2f77fc480bf2ae0f20208e48b5f0f714d4be0d3.

My presumption that removing pod2man from the hosttools would be
unobtrusive was not correct. pod2man is still required for the
opkg-utils build - and I'm not sure how it works upstream.

In the mean time, revert this commit, since it was only ever an sstate
cache efficiency optimization and it breaks the build as-is.

## Testing
I've reset my sumo workspace and am rebuilding opkg-utils. It should reproduce the error seen on the build machine.

@ni/rtos 