### PR TITLE
kernel: package modules.builtin.modinfo

### DIFF
--- a/meta/classes/kernel.bbclass
+++ b/meta/classes/kernel.bbclass
@@ -542,7 +542,7 @@ EXPORT_FUNCTIONS do_compile do_install do_configure
 # kernel-image becomes kernel-image-${KERNEL_VERSION}
 PACKAGES = "${KERNEL_PACKAGE_NAME} ${KERNEL_PACKAGE_NAME}-base ${KERNEL_PACKAGE_NAME}-vmlinux ${KERNEL_PACKAGE_NAME}-image ${KERNEL_PACKAGE_NAME}-dev ${KERNEL_PACKAGE_NAME}-modules"
 FILES_${PN} = ""
-FILES_${KERNEL_PACKAGE_NAME}-base = "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.order ${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin"
+FILES_${KERNEL_PACKAGE_NAME}-base = "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.order ${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin ${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo"
 FILES_${KERNEL_PACKAGE_NAME}-image = ""
 FILES_${KERNEL_PACKAGE_NAME}-dev = "/boot/System.map* /boot/Module.symvers* /boot/config* ${KERNEL_SRC_PATH} ${nonarch_base_libdir}/modules/${KERNEL_VERSION}/build"
 FILES_${KERNEL_PACKAGE_NAME}-vmlinux = "/boot/vmlinux-${KERNEL_VERSION_NAME}"


### PR DESCRIPTION
As of commit 898490c010b [moduleparam: Save information about built-in
modules in separate file] (kernels v5.2-rc1+), modules.builtin.modinfo
is generated as part of the kernel build process.

We package it along with the other module artifacts, so it can be used
by scripts/other build steps.

Signed-off-by: Bruce Ashfield <bruce.ashfield@gmail.com>
Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
(cherry picked from commit 112a4d3b2b4a829dd5657b6533b1c1bb589d6c8e)

---

Cherry pick the above commit from upstream to remove a warning about the `*.modinfo` file not being included in any package.

```
WARNING: linux-nilrt-5.10+gitAUTOINC+198ac57441-r0 do_package: QA Issue: linux-nilrt: Files/directories were installed but not shipped in any package:
  /lib/modules/5.10.47-rt45/modules.builtin.modinfo
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.
linux-nilrt: 1 installed and not shipped files. [installed-vs-shipped]
WARNING: linux-nilrt-debug-5.10+gitAUTOINC+198ac57441-r0 do_package: QA Issue: linux-nilrt-debug: Files/directories were installed but not shipped in any package:
  /lib/modules/5.10.47-rt45-debug/modules.builtin.modinfo
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.
linux-nilrt-debug: 1 installed and not shipped files. [installed-vs-shipped]

```

## Testing
Builds on my dev machine with the 5.10 kernel.

@ni/rtos 