### PR TITLE
insane.bbclass: use _${PN} to namespace native-last

### DIFF
--- a/meta/classes/insane.bbclass
+++ b/meta/classes/insane.bbclass
@@ -1347,7 +1347,7 @@ python () {
     for i in issues:
         package_qa_handle_error("pkgvarcheck", "%s: Variable %s is set as not being package specific, please fix this." % (d.getVar("FILE"), i), d)
 
-    if 'native-last' not in (d.getVar('INSANE_SKIP') or "").split():
+    if 'native-last' not in (d.getVar(d.expand('INSANE_SKIP_${PN}')) or "").split():
         for native_class in ['native', 'nativesdk']:
             if bb.data.inherits_class(native_class, d):
 


### PR DESCRIPTION
The `native-last` QA check verifies that recipes which inherit the
`native` bbclass do so at the end of their recipes. The check is
supposed to be skippable via the INSANE_SKIP mechanism, but its current
implementation does not comprehend the usual _${PN} variable
namespacing, and instead checks `INSANE_SKIP` only.

Instead, let bitbake expand `INSANE_SKIP_${PN}`, so that the check can
be skipped using the same variable as all other skips.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

It seems like the original implementation here might have been a mistake on upstream's part. Neither the [insane.bbclass](https://docs.yoctoproject.org/ref-manual/classes.html?highlight=insane%20bbclass#insane-bbclass) or [native.bbclass](https://docs.yoctoproject.org/ref-manual/classes.html?highlight=native%20last#native-bbclass) documentation suggests that you're supposed to use `INSANE_SKIP` rather than the usual `INSANE_SKIP_${PN}` for skipping the `native-last` QA check.

Once we accept this patch, I'm going to rebase on OE-core/master and submit upstream.

## Testing
* Without this change, meta-nilrt's `rauc-native` bbappend warns with this error:
  ```
  WARNING: /mnt/workspace/sources/meta-rauc/recipes-core/rauc/rauc-native_1.5.1.bb: QA Issue: rauc-native: native/nativesdk class is not inherited last, this can result in unexpected behaviour. Classes inherited after native/nativesdk: update-rc.d.bbclass [native-last]
  WARNING: /mnt/workspace/sources/meta-rauc/recipes-core/rauc/rauc-native_git.bb: QA Issue: rauc-native: native/nativesdk class is not inherited last, this can result in unexpected behaviour. Classes inherited after native/nativesdk: update-rc.d.bbclass [native-last]
  ```
  Asserting `INSANE_SKIP += "native-last"` can bypass the error, but not `INSANE_SKIP_${PN} += "native-last"`.
* With this patch, the latter works.

@ni/rtos 