### PR TITLE
ca-certificates: upgrade 20200601 -> 20210119

### DIFF
--- a/meta/recipes-support/ca-certificates/ca-certificates_20210119.bb
+++ b/meta/recipes-support/ca-certificates/ca-certificates_20210119.bb
@@ -14,7 +14,7 @@ DEPENDS_class-nativesdk = "openssl-native"
 # Need c_rehash from openssl and run-parts from debianutils
 PACKAGE_WRITE_DEPS += "openssl-native debianutils-native"
 
-SRCREV = "b3a8980b781bc9a370e42714a605cd4191bb6c0b"
+SRCREV = "181be7ebd169b4a6fb5d90c3e6dc791e90534144"
 
 SRC_URI = "git://salsa.debian.org/debian/ca-certificates.git;protocol=https \
            file://0002-update-ca-certificates-use-SYSROOT.patch \


### PR DESCRIPTION
0001-certdata2pem.py-use-python3.patch
removed since it is included in 20210119

Signed-off-by: Zheng Ruoqin <zhengrq.fnst@cn.fujitsu.com>
Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>

------

Built the package, diff'd the contents of the certificates directory before and after this change, and verified that the certificates were updated as described in this upstream [commit](https://salsa.debian.org/debian/ca-certificates/-/commit/315ae87762dc2edce56042cfa486eb2d92711338).
AzDO: [255916](https://ni.visualstudio.com/DevCentral/_backlogs/backlog/DSW%20DOE%20RTOS/Work%20Items/?workitem=255916)

@ni/rtos 