### PR TITLE
kernel-devsrc: 5.14+ updates

### DIFF
--- a/meta/recipes-kernel/linux/kernel-devsrc.inc
+++ b/meta/recipes-kernel/linux/kernel-devsrc.inc
@@ -195,10 +195,10 @@ do_install() {
 
 	if [ "${ARCH}" = "x86" ]; then
 	    # files for 'make prepare' to succeed with kernel-devel
-	    cp -a --parents $(find arch/x86 -type f -name "syscall_32.tbl") $kerneldir/build/
-	    cp -a --parents $(find arch/x86 -type f -name "syscalltbl.sh") $kerneldir/build/
-	    cp -a --parents $(find arch/x86 -type f -name "syscallhdr.sh") $kerneldir/build/
-	    cp -a --parents $(find arch/x86 -type f -name "syscall_64.tbl") $kerneldir/build/
+	    cp -a --parents $(find arch/x86 -type f -name "syscall_32.tbl") $kerneldir/build/ 2>/dev/null || :
+	    cp -a --parents $(find arch/x86 -type f -name "syscalltbl.sh") $kerneldir/build/ 2>/dev/null || :
+	    cp -a --parents $(find arch/x86 -type f -name "syscallhdr.sh") $kerneldir/build/ 2>/dev/null || :
+	    cp -a --parents $(find arch/x86 -type f -name "syscall_64.tbl") $kerneldir/build/ 2>/dev/null || :
 	    cp -a --parents arch/x86/tools/relocs_32.c $kerneldir/build/
 	    cp -a --parents arch/x86/tools/relocs_64.c $kerneldir/build/
 	    cp -a --parents arch/x86/tools/relocs.c $kerneldir/build/


### PR DESCRIPTION
Newer upstream kernels >=5.14 won't compile in OpenEmbedded due to
a change in how the files are installed which results in an error
like the following:
DEBUG: Executing shell function do_install
cp: missing destination file operand after '/<path_to_nilrt>/nilrt
/build/tmp-glibc/work/x64-nilrt-linux/kernel-devsrc-next/1.0-r0
/image/lib/modules/5.15.0-rt17-next/build/'
Try 'cp --help' for more information.
WARNING: exit code 1 from a shell command.
ERROR: Execution of '/<path_to_nilrt>/nilrt/build/tmp-glibc/work
/x64-nilrt-linux/kernel-devsrc-next/1.0-r0/temp
/run.do_install.654' failed with exit code 1:
cp: missing destination file operand after '/<path_to_nilrt>
/nilrt/build/tmp-glibc/work/x64-nilrt-linux/kernel-devsrc-next
/1.0-r0/image/lib/modules/5.15.0-rt17-next/build/'
Try 'cp --help' for more information.

To fix this, we need to backport of this change into our source
tree:
5debc9bc25110b836b76927c61b2455e5e235a84

We have moved this file around a bit, and thus can't apply that
change directly.

Original upstream commit message follows:
commit 6218d0f6b8dec [x86/syscalls: Switch to generic syscalltbl.sh]
means that x86 no longer has a syscall script to copy, which causes
a build error.

We already copy the generic syscall script (in scripts), so we just
catch errors for the copies to support older and 5.14+ kernels in
the same devsrc recipe.

Signed-off-by: Bruce Ashfield <bruce.ashfield@gmail.com>
Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>

Signed-off-by: James Minor <james.minor@ni.com>