### PR TITLE
expat: pull from github releases

### DIFF
--- a/meta/recipes-core/expat/expat_2.2.10.bb
+++ b/meta/recipes-core/expat/expat_2.2.10.bb
@@ -6,11 +6,15 @@ LICENSE = "MIT"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=9e2ce3b3c4c0f2670883a23bbd7c37a9"
 
-SRC_URI = "${SOURCEFORGE_MIRROR}/expat/expat-${PV}.tar.bz2 \
+VERSION_TAG = "${@d.getVar('PV').replace('.', '_')}"
+
+SRC_URI = "https://github.com/libexpat/libexpat/releases/download/R_${VERSION_TAG}/expat-${PV}.tar.bz2  \
            file://libtool-tag.patch \
 	   file://run-ptest \
 	   file://0001-Add-output-of-tests-result.patch \
 	  "
+
+UPSTREAM_CHECK_URI = "https://github.com/libexpat/libexpat/releases/"
 
 SRC_URI[sha256sum] = "b2c160f1b60e92da69de8e12333096aeb0c3bf692d41c60794de278af72135a5"
 


### PR DESCRIPTION
sometimes we can find release tarballs from sourceforge are not fully
distributed along all download mirrors leading to fetching failures,
depending on what download mirror will be chosen by sourceforge
servers.
As the project moved to github anyway, it's better to pull the tarballs
directly from github releases - serving the very same static artifacts.

Add an override UPSTREAM_CHECK_URI to enable devtool upgrade checks

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>
(backported from commit 2a1743ace5aa41b188f77853d0f00c9e5a359c6d)
Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
(cherry picked from commit 75cdae00b80e0a64bb02f274cdf8b9a321bd57e5)
Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

The sourceforge mirrors are sketchy and do not always properly replicate artifacts across regions. Depending on which mirror a build machine gets directed to, it may get an HTTP 404 error when trying to fetch the expat sources. Expat upstream has moved to github and releases artifacts there. Upstream yocto [has switched](https://lists.openembedded.org/g/openembedded-core/message/156460) their recipes to fetch from GH instead.

This PR cherry-picks the upstream yocto/hardknott commit which switches the fetch to GH.

# Testing
The original fetch error doesn't reproduce on my dev machine - presumably because I am getting directed to a proper mirror. But I have verified that the recipe builds on my dev machine with this commit, and it is already upstreamed with hardknott, so it should be pretty safe to pull regardless.

@ni/rtos 