### PR TITLE
Upgrade opkg and opkg-utils to _0.5.0

### DIFF
--- a/meta/recipes-devtools/opkg-utils/opkg-utils_0.5.0.bb
+++ b/meta/recipes-devtools/opkg-utils/opkg-utils_0.5.0.bb
@@ -14,8 +14,7 @@ SRC_URI = "http://git.yoctoproject.org/cgit/cgit.cgi/${BPN}/snapshot/${BPN}-${PV
            "
 UPSTREAM_CHECK_URI = "http://git.yoctoproject.org/cgit/cgit.cgi/opkg-utils/refs/"
 
-SRC_URI[md5sum] = "025b19744e5c7fc1c8380e17df1fcc64"
-SRC_URI[sha256sum] = "528635e674addea5c2b3a3268404ad04a952c4f410d17c3d754f5dd5529770c9"
+SRC_URI[sha256sum] = "55733c0f8ffde2bb4f9593cfd66a1f68e6a2f814e8e62f6fd78472911c818c32"
 
 TARGET_CC_ARCH += "${LDFLAGS}"
 

--- a/meta/recipes-devtools/opkg/opkg_0.5.0.bb
+++ b/meta/recipes-devtools/opkg/opkg_0.5.0.bb
@@ -18,8 +18,7 @@ SRC_URI = "http://downloads.yoctoproject.org/releases/${BPN}/${BPN}-${PV}.tar.gz
            file://run-ptest \
 "
 
-SRC_URI[md5sum] = "5dc41ad37d88803b5e0f456a9c5a0811"
-SRC_URI[sha256sum] = "a1214a75fa34fb9228db8da47308e0e711b1c93fd8938cf164c10fd28eb50f1e"
+SRC_URI[sha256sum] = "559c3e1b893abaa1dd473ce3a9a5f7dd3f60ceb6cd14caaef76ddf0f7721ad1c"
 
 # This needs to be before ptest inherit, otherwise all ptest files end packaged
 # in libopkg package if OPKGLIBDIR == libdir, because default
@@ -39,11 +38,9 @@ PACKAGECONFIG[gpg] = "--enable-gpg,--disable-gpg,\
     "
 PACKAGECONFIG[curl] = "--enable-curl,--disable-curl,curl"
 PACKAGECONFIG[ssl-curl] = "--enable-ssl-curl,--disable-ssl-curl,curl openssl"
-PACKAGECONFIG[openssl] = "--enable-openssl,--disable-openssl,openssl"
 PACKAGECONFIG[sha256] = "--enable-sha256,--disable-sha256"
 PACKAGECONFIG[libsolv] = "--with-libsolv,--without-libsolv,libsolv"
 
-EXTRA_OECONF += " --disable-pathfinder"
 EXTRA_OECONF_class-native = "--localstatedir=/${@os.path.relpath('${localstatedir}', '${STAGING_DIR_NATIVE}')} --sysconfdir=/${@os.path.relpath('${sysconfdir}', '${STAGING_DIR_NATIVE}')}"
 
 do_install_append () {
@@ -59,18 +56,6 @@ do_install_ptest () {
 	sed -i -e '/@echo $^/d' ${D}${PTEST_PATH}/tests/Makefile
 	sed -i -e '/@PYTHONPATH=. $(PYTHON) $^/a\\t@if [ "$$?" != "0" ];then echo "FAIL:"$^;else echo "PASS:"$^;fi' ${D}${PTEST_PATH}/tests/Makefile
 }
-
-WARN_QA_append += "openssl-deprecation"
-QAPKGTEST[openssl-deprecation] = "package_qa_check_openssl_deprecation"
-def package_qa_check_openssl_deprecation (package, d, messages):
-    sane = True
-
-    pkgconfig = (d.getVar("PACKAGECONFIG") or "").split()
-    if pkgconfig and 'openssl' in pkgconfig:
-        package_qa_add_message(messages, 'openssl-deprecation', '"openssl" in opkg.bb PACKAGECONFIG. Feed signature checking with OpenSSL will be deprecated in the next opkg release. Consider using GPG checking instead.')
-        sane = False
-
-    return sane
 
 
 RDEPENDS_${PN} = "${VIRTUAL-RUNTIME_update-alternatives} opkg-arch-config libarchive"


### PR DESCRIPTION
The opkg project released version 0.5.0 last week. Yocto upstream has accepted recipe commits into master-next which upgrades the `opkg` and `opkg-utils` recipe versions to 0.5.0. This PR cherry-picks (with minor rebase) those commits to our hardknott mainline.

Note: I had to convert the task overrides syntax from `:` to `_` during the cherry-pick, since hardknott uses the old syntax. Otherwise, there are no substantial changes.

# Testing
Recipe builds on my dev machine.

# Merging
I will post an accompanying PR to pull these same changes into the sumo mainline, so that we can ship opkg 0.5.0 for the 21.8 release.

@ni/rtos 