### PR TITLE
Use https in github repo SRC_URIS

### DIFF
--- a/meta/recipes-connectivity/connman/connman-gnome_0.7.bb
+++ b/meta/recipes-connectivity/connman/connman-gnome_0.7.bb
@@ -10,7 +10,7 @@ DEPENDS = "gtk+3 dbus-glib dbus-glib-native intltool-native gettext-native"
 
 # 0.7 tag
 SRCREV = "cf3c325b23dae843c5499a113591cfbc98acb143"
-SRC_URI = "git://github.com/connectivity/connman-gnome.git \
+SRC_URI = "git://github.com/connectivity/connman-gnome.git;protocol=https \
            file://0001-Removed-icon-from-connman-gnome-about-applet.patch \
            file://null_check_for_ipv4_config.patch \
            file://images/* \

--- a/meta/recipes-core/fts/fts.bb
+++ b/meta/recipes-core/fts/fts.bb
@@ -10,7 +10,7 @@ SECTION = "libs"
 SRCREV = "944333aed9dc24cfa76cc64bfe70c75d25652753"
 PV = "1.2+git${SRCPV}"
 
-SRC_URI = "git://github.com/voidlinux/musl-fts \
+SRC_URI = "git://github.com/voidlinux/musl-fts;protocol=https \
 "
 S = "${WORKDIR}/git"
 

--- a/meta/recipes-core/glibc/cross-localedef-native_2.24.bb
+++ b/meta/recipes-core/glibc/cross-localedef-native_2.24.bb
@@ -25,7 +25,7 @@ SRCREV_glibc ?= "ea23815a795f72035262953dad5beb03e09c17dd"
 SRCREV_localedef ?= "29869b6dc11427c5bab839bdb155c85a7c644c71"
 
 SRC_URI = "${GLIBC_GIT_URI};branch=${SRCBRANCH};name=glibc \
-           git://github.com/kraj/localedef;branch=master;name=localedef;destsuffix=git/localedef \
+           git://github.com/kraj/localedef;branch=master;name=localedef;destsuffix=git/localedef;protocol=https \
            file://0016-timezone-re-written-tzselect-as-posix-sh.patch \
            file://0017-Remove-bash-dependency-for-nscd-init-script.patch \
            file://0018-eglibc-Cross-building-and-testing-instructions.patch \

--- a/meta/recipes-core/musl/musl-utils.bb
+++ b/meta/recipes-core/musl/musl-utils.bb
@@ -11,7 +11,7 @@ SECTION = "utils"
 PV = "20170421"
 
 SRCREV = "fb5630138ccabbbc14a19d372096a04e42573c7d"
-SRC_URI = "git://github.com/boltlinux/musl-utils"
+SRC_URI = "git://github.com/boltlinux/musl-utils;protocol=https"
 
 inherit autotools
 

--- a/meta/recipes-core/ovmf/ovmf_git.bb
+++ b/meta/recipes-core/ovmf/ovmf_git.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://OvmfPkg/License.txt;md5=343dc88e82ff33d042074f62050c3
 PACKAGECONFIG ??= ""
 PACKAGECONFIG[secureboot] = ",,,"
 
-SRC_URI = "git://github.com/tianocore/edk2.git;branch=master \
+SRC_URI = "git://github.com/tianocore/edk2.git;branch=master;protocol=https \
 	file://0001-ia32-Dont-use-pie.patch \
 	file://0002-ovmf-update-path-to-native-BaseTools.patch \
 	file://0003-BaseTools-makefile-adjust-to-build-in-under-bitbake.patch \

--- a/meta/recipes-core/systemd/systemd.inc
+++ b/meta/recipes-core/systemd/systemd.inc
@@ -16,6 +16,6 @@ LIC_FILES_CHKSUM = "file://LICENSE.GPL2;md5=751419260aa954499f7abaabaa882bbe \
 
 SRCREV = "46659f7deb962f55c728e70597e37c2a3ab6326d"
 
-SRC_URI = "git://github.com/systemd/systemd.git;protocol=git"
+SRC_URI = "git://github.com/systemd/systemd.git;protocol=https"
 
 S = "${WORKDIR}/git"

--- a/meta/recipes-core/update-rc.d/update-rc.d_0.7.bb
+++ b/meta/recipes-core/update-rc.d/update-rc.d_0.7.bb
@@ -11,7 +11,7 @@ PR = "r5"
 # Revision corresponding to tag update-rc.d_0.7
 SRCREV = "eca680ddf28d024954895f59a241a622dd575c11"
 
-SRC_URI = "git://github.com/philb/update-rc.d.git \
+SRC_URI = "git://github.com/philb/update-rc.d.git;protocol=https \
            file://add-verbose.patch \
            file://check-if-symlinks-are-valid.patch \
            file://fix-to-handle-priority-numbers-correctly.patch \

--- a/meta/recipes-devtools/bootchart2/bootchart2_0.14.8.bb
+++ b/meta/recipes-devtools/bootchart2/bootchart2_0.14.8.bb
@@ -90,7 +90,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=44ac4678311254db62edf8fd39cb8124"
 
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d+\.\d+(\.\d+)*)"
 
-SRC_URI = "git://github.com/xrmx/bootchart.git \
+SRC_URI = "git://github.com/xrmx/bootchart.git;protocol=https \
            file://bootchartd_stop.sh \
            file://0001-Fixed-Missing-default-value-for-BOOTLOG_DEST.patch \
            file://0001-collector-Allocate-space-on-heap-for-chunks.patch \

--- a/meta/recipes-devtools/build-compare/build-compare_git.bb
+++ b/meta/recipes-devtools/build-compare/build-compare_git.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "https://github.com/openSUSE/build-compare"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 
-SRC_URI = "git://github.com/openSUSE/build-compare.git \
+SRC_URI = "git://github.com/openSUSE/build-compare.git;protocol=https \
            file://Rename-rpm-check.sh-to-pkg-diff.sh.patch;striplevel=1 \
            file://Ignore-DWARF-sections.patch;striplevel=1 \
            file://0001-Add-support-for-deb-and-ipk-packaging.patch \

--- a/meta/recipes-devtools/createrepo-c/createrepo-c_git.bb
+++ b/meta/recipes-devtools/createrepo-c/createrepo-c_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/rpm-software-management/createrepo_c/wiki"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/rpm-software-management/createrepo_c \
+SRC_URI = "git://github.com/rpm-software-management/createrepo_c;protocol=https \
            file://0001-Do-not-set-PYTHON_INSTALL_DIR-by-running-python.patch \
            file://0001-Correctly-install-the-shared-library.patch \
            "

--- a/meta/recipes-devtools/distcc/distcc_3.2.bb
+++ b/meta/recipes-devtools/distcc/distcc_3.2.bb
@@ -14,7 +14,7 @@ PACKAGECONFIG[popt] = "--without-included-popt,--with-included-popt,popt"
 
 RRECOMMENDS_${PN} = "avahi-daemon"
 
-SRC_URI = "git://github.com/akuster/distcc.git;branch=${PV} \
+SRC_URI = "git://github.com/akuster/distcc.git;branch=${PV};protocol=https \
            file://separatebuilddir.patch \
            file://0001-zeroconf-Include-fcntl.h.patch \
            file://default \

--- a/meta/recipes-devtools/dnf/dnf_2.7.5.bb
+++ b/meta/recipes-devtools/dnf/dnf_2.7.5.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
                     file://PACKAGE-LICENSING;md5=bfc29916e11321be06924c4fb096fdcc \
                    "
 
-SRC_URI = "git://github.com/rpm-software-management/dnf.git \
+SRC_URI = "git://github.com/rpm-software-management/dnf.git;protocol=https \
            file://0001-Corretly-install-tmpfiles.d-configuration.patch \
            file://0001-Do-not-hardcode-etc-and-systemd-unit-directories.patch \
            file://0005-Do-not-prepend-installroot-to-logdir.patch \

--- a/meta/recipes-devtools/file/file_5.32.bb
+++ b/meta/recipes-devtools/file/file_5.32.bb
@@ -14,7 +14,7 @@ DEPENDS_class-native = "zlib-native"
 # Blacklist a bogus tag in upstream check
 UPSTREAM_CHECK_GITTAGREGEX = "FILE(?P<pver>(?!6_23).+)"
 
-SRC_URI = "git://github.com/file/file.git \
+SRC_URI = "git://github.com/file/file.git;protocol=https \
         file://debian-742262.patch \
         file://0001-Add-P-prompt-into-Usage-info.patch \
         "

--- a/meta/recipes-devtools/gcc/gcc-7.3.inc
+++ b/meta/recipes-devtools/gcc/gcc-7.3.inc
@@ -26,7 +26,7 @@ LIC_FILES_CHKSUM = "\
 #RELEASE = "7-20170504"
 BASEURI ?= "${GNU_MIRROR}/gcc/gcc-${PV}/gcc-${PV}.tar.xz"
 #SRCREV = "f7cf798b73fd1a07098f9a490deec1e2a36e0bed"
-#BASEURI ?= "git://github.com/gcc-mirror/gcc;branch=gcc-6-branch;protocol=git"
+#BASEURI ?= "git://github.com/gcc-mirror/gcc;branch=gcc-6-branch;protocol=https"
 #BASEURI ?= "http://mirrors.concertpass.com/gcc/snapshots/${RELEASE}/gcc-${RELEASE}.tar.bz2"
 
 SRC_URI = "\

--- a/meta/recipes-devtools/libcomps/libcomps_git.bb
+++ b/meta/recipes-devtools/libcomps/libcomps_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "Libcomps is alternative for yum.comps library (which is for managing 
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/rpm-software-management/libcomps.git \
+SRC_URI = "git://github.com/rpm-software-management/libcomps.git;protocol=https \
            file://0001-Do-not-set-PYTHON_INSTALL_DIR-by-running-python.patch \
            file://0002-Set-library-installation-path-correctly.patch \
            file://0001-Make-__comps_objmrtree_all-static-inline.patch \

--- a/meta/recipes-devtools/libdnf/libdnf_0.11.1.bb
+++ b/meta/recipes-devtools/libdnf/libdnf_0.11.1.bb
@@ -2,7 +2,7 @@ SUMMARY = "Library providing simplified C and Python API to libsolv"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/rpm-software-management/libdnf \
+SRC_URI = "git://github.com/rpm-software-management/libdnf;protocol=https \
            file://0001-FindGtkDoc.cmake-drop-the-requirement-for-GTKDOC_SCA.patch \
            file://0002-Prefix-sysroot-path-to-introspection-tools-path.patch \
            file://0003-Set-the-library-installation-directory-correctly.patch \

--- a/meta/recipes-devtools/librepo/librepo_1.8.1.bb
+++ b/meta/recipes-devtools/librepo/librepo_1.8.1.bb
@@ -2,7 +2,7 @@ SUMMARY = " A library providing C and Python (libcURL like) API for downloading 
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/rpm-software-management/librepo.git \
+SRC_URI = "git://github.com/rpm-software-management/librepo.git;protocol=https \
            file://0002-Do-not-try-to-obtain-PYTHON_INSTALL_DIR-by-running-p.patch \
            file://0004-Set-gpgme-variables-with-pkg-config-not-with-cmake-m.patch \
            "

--- a/meta/recipes-devtools/llvm/llvm_git.bb
+++ b/meta/recipes-devtools/llvm/llvm_git.bb
@@ -23,7 +23,7 @@ SRCREV = "089d4c0c490687db6c75f1d074e99c4d42936a50"
 PV = "6.0"
 BRANCH = "release_60"
 PATCH_VERSION = "0"
-SRC_URI = "git://github.com/llvm-mirror/llvm.git;branch=${BRANCH};protocol=http \
+SRC_URI = "git://github.com/llvm-mirror/llvm.git;branch=${BRANCH};protocol=http;protocol=https \
            file://0001-llvm-TargetLibraryInfo-Undefine-libc-functions-if-th.patch \
            file://0002-llvm-allow-env-override-of-exe-path.patch \
            file://0001-Disable-generating-a-native-llvm-config.patch \

--- a/meta/recipes-devtools/ninja/ninja_1.8.2.bb
+++ b/meta/recipes-devtools/ninja/ninja_1.8.2.bb
@@ -7,7 +7,7 @@ DEPENDS = "re2c-native ninja-native"
 
 SRCREV = "253e94c1fa511704baeb61cf69995bbf09ba435e"
 
-SRC_URI = "git://github.com/ninja-build/ninja.git;branch=release"
+SRC_URI = "git://github.com/ninja-build/ninja.git;branch=release;protocol=https"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>.*)"
 
 S = "${WORKDIR}/git"

--- a/meta/recipes-devtools/rpm/rpm_4.14.1.bb
+++ b/meta/recipes-devtools/rpm/rpm_4.14.1.bb
@@ -24,7 +24,7 @@ HOMEPAGE = "http://www.rpm.org"
 LICENSE = "GPL-2.0"
 LIC_FILES_CHKSUM = "file://COPYING;md5=c0bf017c0fd1920e6158a333acabfd4a"
 
-SRC_URI = "git://github.com/rpm-software-management/rpm;branch=rpm-4.14.x \
+SRC_URI = "git://github.com/rpm-software-management/rpm;branch=rpm-4.14.x;protocol=https \
            file://0001-Do-not-add-an-unsatisfiable-dependency-when-building.patch \
            file://0001-Do-not-read-config-files-from-HOME.patch \
            file://0001-When-cross-installing-execute-package-scriptlets-wit.patch \

--- a/meta/recipes-extended/chkconfig/chkconfig-alternatives-native_1.3.59.bb
+++ b/meta/recipes-extended/chkconfig/chkconfig-alternatives-native_1.3.59.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 # The sysroot branch is 1.3.59 + some git commits from master + --sysroot
 # support for alternatives.
-SRC_URI = "git://github.com/kergoth/chkconfig;branch=sysroot"
+SRC_URI = "git://github.com/kergoth/chkconfig;branch=sysroot;protocol=https"
 S = "${WORKDIR}/git"
 UPSTREAM_CHECK_GITTAGREGEX = "chkconfig-(?P<pver>(\d+(\.\d+)+))"
 

--- a/meta/recipes-extended/iputils/iputils_s20161105.bb
+++ b/meta/recipes-extended/iputils/iputils_s20161105.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://ping.c;beginline=1;endline=35;md5=f9ceb201733e9a6cf8f
 
 DEPENDS = "gnutls libcap libgcrypt"
 
-SRC_URI = "git://github.com/iputils/iputils \
+SRC_URI = "git://github.com/iputils/iputils;protocol=https \
            file://0001-Fix-build-on-MUSL.patch \
            "
 S = "${WORKDIR}/git"

--- a/meta/recipes-extended/libnsl/libnsl2_git.bb
+++ b/meta/recipes-extended/libnsl/libnsl2_git.bb
@@ -15,7 +15,7 @@ PV = "1.0.5+git${SRCPV}"
 
 SRCREV = "dfa2f313524aff9243c4d8ce1bace73786478356"
 
-SRC_URI = "git://github.com/thkukuk/libnsl \
+SRC_URI = "git://github.com/thkukuk/libnsl;protocol=https \
            file://0001-include-sys-cdefs.h-explicitly.patch \
            file://0002-Define-glibc-specific-macros.patch \
            file://0001-nis_call.c-Include-stdint.h-for-uintptr_t-definition.patch \

--- a/meta/recipes-extended/libsolv/libsolv_0.7.17.bb
+++ b/meta/recipes-extended/libsolv/libsolv_0.7.17.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.BSD;md5=62272bd11c97396d4aaf1c41bc11f7d8"
 
 DEPENDS = "expat zlib"
 
-SRC_URI = "git://github.com/openSUSE/libsolv.git \
+SRC_URI = "git://github.com/openSUSE/libsolv.git;protocol=https \
 "
 
 SRCREV = "4bc791c0d235eb14bfe4c5da607206bfdfa6983d"

--- a/meta/recipes-extended/lsb/lsbinitscripts_9.79.bb
+++ b/meta/recipes-extended/lsb/lsbinitscripts_9.79.bb
@@ -11,7 +11,7 @@ RCONFLICTS_${PN} = "initscripts-functions"
 LIC_FILES_CHKSUM = "file://COPYING;md5=ebf4e8b49780ab187d51bd26aaa022c6"
 
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/fedora-sysv/initscripts \
+SRC_URI = "git://github.com/fedora-sysv/initscripts;protocol=https \
            file://functions.patch \
            file://0001-functions-avoid-exit-1-which-causes-init-scripts-to-.patch \
           " 

--- a/meta/recipes-extended/ltp/ltp_20180118.bb
+++ b/meta/recipes-extended/ltp/ltp_20180118.bb
@@ -23,7 +23,7 @@ CFLAGS_append_powerpc64 = " -D__SANE_USERSPACE_TYPES__"
 CFLAGS_append_mipsarchn64 = " -D__SANE_USERSPACE_TYPES__"
 SRCREV = "731cd34e682d297b207668be8b1d15320a9ac1b1"
 
-SRC_URI = "git://github.com/linux-test-project/ltp.git \
+SRC_URI = "git://github.com/linux-test-project/ltp.git;protocol=https \
            file://0001-configure-add-knob-to-control-numa-support.patch \
            file://0001-configure-Fix-default-value-of-without-numa-switch-i.patch \
            file://0003-Add-knob-to-control-tirpc-support.patch \

--- a/meta/recipes-graphics/eglinfo/eglinfo.inc
+++ b/meta/recipes-graphics/eglinfo/eglinfo.inc
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=8d4f33bc3add976f7dfae85dab66f03c"
 
 DEPENDS = "virtual/egl"
 
-SRC_URI = "git://github.com/dv1/eglinfo.git;branch=master \
+SRC_URI = "git://github.com/dv1/eglinfo.git;branch=master;protocol=https \
            file://0001-Add-STAGING_INCDIR-to-searchpath-for-egl-headers.patch \
           "
 SRCREV = "4b317648ec6cf39556a9e5d8078f605bc0edd5de"

--- a/meta/recipes-graphics/mx/mx-1.0_1.4.7.bb
+++ b/meta/recipes-graphics/mx/mx-1.0_1.4.7.bb
@@ -7,7 +7,7 @@ PV = "1.4.7+git${SRCPV}"
 # Exclude x.99.x versions from upstream checks
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>^\d+(\.(?!99)\d+)+)"
 
-SRC_URI = "git://github.com/clutter-project/mx.git;branch=mx-1.4 \
+SRC_URI = "git://github.com/clutter-project/mx.git;branch=mx-1.4;protocol=https \
 	   file://fix-test-includes.patch \
 	  "
 S = "${WORKDIR}/git"

--- a/meta/recipes-graphics/vulkan/assimp_4.1.0.bb
+++ b/meta/recipes-graphics/vulkan/assimp_4.1.0.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2119edef0916b0bd511cb3c731076271"
 
 DEPENDS = "zlib"
 
-SRC_URI = "git://github.com/assimp/assimp.git"
+SRC_URI = "git://github.com/assimp/assimp.git;protocol=https"
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>(\d+(\.\d+)+))"
 
 SRCREV = "80799bdbf90ce626475635815ee18537718a05b1"

--- a/meta/recipes-graphics/vulkan/vulkan-demos_git.bb
+++ b/meta/recipes-graphics/vulkan/vulkan-demos_git.bb
@@ -5,7 +5,7 @@ DEPENDS = "zlib"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=dcf473723faabf17baa9b5f2207599d0 \
                     file://triangle/triangle.cpp;endline=12;md5=bccd1bf9cadd9e10086cf7872157e4fa"
 
-SRC_URI = "git://github.com/SaschaWillems/Vulkan.git \
+SRC_URI = "git://github.com/SaschaWillems/Vulkan.git;protocol=https \
            file://0001-Support-installing-demos-support-out-of-tree-builds.patch \
            file://0001-Don-t-build-demos-with-questionably-licensed-data.patch \
            file://0001-Fix-build-on-x86.patch \

--- a/meta/recipes-graphics/vulkan/vulkan_1.0.65.2.bb
+++ b/meta/recipes-graphics/vulkan/vulkan_1.0.65.2.bb
@@ -10,7 +10,7 @@ SECTION = "libs"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=99c647ca3d4f6a4b9d8628f757aad156 \
                     file://loader/loader.c;endline=25;md5=a87cd5442291c23d1fce4eece4cfde9d"
-SRC_URI = "git://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers.git;branch=sdk-1.0.65 \
+SRC_URI = "git://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers.git;branch=sdk-1.0.65;protocol=https \
            file://demos-Don-t-build-tri-or-cube.patch \
            "
 SRCREV = "73486a1a169d862d5210e2ad520d95319a2383fa"

--- a/meta/recipes-graphics/xinput-calibrator/xinput-calibrator_git.bb
+++ b/meta/recipes-graphics/xinput-calibrator/xinput-calibrator_git.bb
@@ -12,7 +12,7 @@ inherit autotools pkgconfig distro_features_check
 REQUIRED_DISTRO_FEATURES = "x11"
 
 SRCREV = "03dadf55109bd43d3380f040debe9f82f66f2f35"
-SRC_URI = "git://github.com/tias/xinput_calibrator.git \
+SRC_URI = "git://github.com/tias/xinput_calibrator.git;protocol=https \
            file://30xinput_calibrate.sh \
            file://Allow-xinput_calibrator_pointercal.sh-to-be-run-as-n.patch \
            file://xinput_calibrator-Add-support-for-libinput.patch"

--- a/meta/recipes-kernel/cryptodev/cryptodev.inc
+++ b/meta/recipes-kernel/cryptodev/cryptodev.inc
@@ -3,7 +3,7 @@ HOMEPAGE = "http://cryptodev-linux.org/"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/cryptodev-linux/cryptodev-linux"
+SRC_URI = "git://github.com/cryptodev-linux/cryptodev-linux;protocol=https"
 SRCREV = "87d959d9a279c055b361de8e730fab6a7144edd7"
 
 S = "${WORKDIR}/git"

--- a/meta/recipes-multimedia/x264/x264_git.bb
+++ b/meta/recipes-multimedia/x264/x264_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 DEPENDS = "nasm-native"
 
-SRC_URI = "git://github.com/mirror/x264;branch=stable \
+SRC_URI = "git://github.com/mirror/x264;branch=stable;protocol=https \
            file://don-t-default-to-cortex-a9-with-neon.patch \
            file://Fix-X32-build-by-disabling-asm.patch \
            "

--- a/meta/recipes-sato/l3afpad/l3afpad_git.bb
+++ b/meta/recipes-sato/l3afpad/l3afpad_git.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
 DEPENDS = "gtk+3 intltool-native gettext-native"
 
 PV = "0.8.18.1.11+git${SRCPV}"
-SRC_URI = "git://github.com/stevenhoneyman/l3afpad.git"
+SRC_URI = "git://github.com/stevenhoneyman/l3afpad.git;protocol=https"
 SRCREV ="3cdccdc9505643e50f8208171d9eee5de11a42ff"
 
 S = "${WORKDIR}/git"

--- a/meta/recipes-support/libatomic-ops/libatomic-ops_7.6.2.bb
+++ b/meta/recipes-support/libatomic-ops/libatomic-ops_7.6.2.bb
@@ -10,7 +10,7 @@ PV .= "+git${SRCPV}"
 SRCBRANCH ?= "release-7_6"
 
 SRCREV = "5ae4b4aeea2baf13752d07e3038c47f70f06dcac"
-SRC_URI = "git://github.com/ivmai/libatomic_ops;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/ivmai/libatomic_ops;branch=${SRCBRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta/recipes-support/lz4/lz4_1.7.4.bb
+++ b/meta/recipes-support/lz4/lz4_1.7.4.bb
@@ -10,7 +10,7 @@ PE = "1"
 
 SRCREV = "7bb64ff2b69a9f8367de9ab483cdadf42b4c1b65"
 
-SRC_URI = "git://github.com/lz4/lz4.git \
+SRC_URI = "git://github.com/lz4/lz4.git;protocol=https \
            file://0001-tests-Makefile-don-t-use-LIBDIR-as-variable.patch \
            file://run-ptest \
 "

--- a/meta/recipes-support/p11-kit/p11-kit_0.22.1.bb
+++ b/meta/recipes-support/p11-kit/p11-kit_0.22.1.bb
@@ -6,7 +6,7 @@ inherit autotools gettext pkgconfig gtk-doc
 
 DEPENDS = "libtasn1 libffi"
 
-SRC_URI = "git://github.com/p11-glue/p11-kit \
+SRC_URI = "git://github.com/p11-glue/p11-kit;protocol=https \
            file://0001-LINGUAS-drop-the-languages-for-which-upstream-does-n.patch \
            "
 SRCREV = "bfb3bd47aa48983f5349479bca598403097ff81c"


### PR DESCRIPTION
Github is moving to deprecate the git protocol in its repos. Update all
github URIs to use the `https` protocol.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

This patchset was partially generated using a backported version of the [`convert-srcuri.py`](https://git.openembedded.org/openembedded-core/tree/scripts/contrib/convert-srcuri.py?id=5e2fc4676b8944fc1d36d567bb2d1ff4cff32294) script that Richard Purdie authored for OE upstream, when the community was mass-converting recipes over to use `protocol=https`. I removed the additional logic from the script to append `branch=master`, because it was more hassle than it was worth. I ran the script against this layer and manually checked the results. The script caught 95% of conversions, and I manually fixed the rest.

# Testing
1. Applied the "warning" commit from [ni/bitbake #6](https://github.com/ni/bitbake/pull/6).
2. Ran `bitbake -n ${targets}` using all the recipe targets which we currently build in the `NIOpenEmbedded` component, and recorded the *many* recipes which failed.
3. Applied this patchset to the meta layer.
4. Cleaned and re-ran bitbake and confirmed that there are now no recipes which warn about using the git protocol with github.

@ni/rtos 