### PR TITLE
Drop sdk toolchain and connman out-of-tree commits

### DIFF
--- a/meta/recipes-connectivity/connman/connman/connman
+++ b/meta/recipes-connectivity/connman/connman/connman
@@ -56,7 +56,7 @@ do_start() {
 }
 
 do_stop() {
-	start-stop-daemon --stop --name connmand --quiet --oknodo
+	start-stop-daemon --stop --name connmand --quiet
 }
 
 case "$1" in

--- a/meta/recipes-core/packagegroups/packagegroup-core-standalone-sdk-target.bb
+++ b/meta/recipes-core/packagegroups/packagegroup-core-standalone-sdk-target.bb
@@ -12,7 +12,6 @@ RDEPENDS_${PN} = "\
     libatomic-dev \
     libstdc++ \
     libstdc++-dev \
-    libstdc++-staticdev \
     ${LIBC_DEPENDENCIES} \
     "
 


### PR DESCRIPTION
The team decided that support for these packages was no longer required.
We no longer build the SDK toolchain, and connman is not used in CG images.

AzDO: [1580083](https://ni.visualstudio.com/DevCentral/_workitems/edit/1580083)

@ni/rtos 