### PR TITLE
kernel-module-split.bbclass: fix kernel modules getting marked as CON…

### DIFF
--- a/meta/classes/kernel-module-split.bbclass
+++ b/meta/classes/kernel-module-split.bbclass
@@ -103,7 +103,10 @@ python split_kernel_module_packages () {
         files = d.getVar('FILES_%s' % pkg)
         files = "%s /etc/modules-load.d/%s.conf /etc/modprobe.d/%s.conf" % (files, basename, basename)
         d.setVar('FILES_%s' % pkg, files)
-        d.setVar('CONFFILES_%s' % pkg, files)
+
+        conffiles = d.getVar('CONFFILES_%s' % pkg)
+        conffiles = "%s /etc/modules-load.d/%s.conf /etc/modprobe.d/%s.conf" % (conffiles, basename, basename)
+        d.setVar('CONFFILES_%s' % pkg, conffiles)
 
         if "description" in vals:
             old_desc = d.getVar('DESCRIPTION_' + pkg) or ""


### PR DESCRIPTION
kernel-module-split.bbclass: fix kernel modules getting marked as CONFFILES

Yi pointed out that commit 1a70a92d1f10 ("kernel-module-split.bbclass:
identify kernel modconf files as configuration files") is
unintentionally adding the actual kernel /lib/modules .ko files to the
CONFFILES variable.

The root cause is the re-use of the 'files' variable in that commit.
Fix it by using a separate variable to keep track of the generated
module .conf files that need to be marked as configuration files.

Fixes: 1a70a92d1f10 ("kernel-module-split.bbclass: identify kernel modconf files as configuration files")
Reported-by: Yi Zhao <yi.zhao@windriver.com>
Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>
Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
(cherry picked from commit db5f2ca532db4f0d2e05b7cb5f9d146e1dd76ab3)
Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

NI AZDO: [Task 1856146](https://dev.azure.com/ni/DevCentral/_workitems/edit/1856146)

# Maintenance
This is a cherry-pick from upstream.

# Testing
Currently running test builds of `linux-nilrt` with this change. Conffiles changes aren't likely to break anything functionally, so I don't expect any issues.

@ni/rtos 