### PR TITLE
[hardknott] sudo: add /etc/sudoers to sudo-lib conffiles

### DIFF
--- a/meta/recipes-extended/sudo/sudo.inc
+++ b/meta/recipes-extended/sudo/sudo.inc
@@ -24,8 +24,6 @@ PACKAGECONFIG ??= ""
 PACKAGECONFIG[zlib] = "--enable-zlib,--disable-zlib,zlib"
 PACKAGECONFIG[pam-wheel] = ",,,pam-plugin-wheel"
 
-CONFFILES_${PN} = "${sysconfdir}/sudoers"
-
 EXTRA_OECONF = "--with-editor=${base_bindir}/vi --with-env-editor"
 
 EXTRA_OECONF_append_libc-musl = " --disable-hardening "

--- a/meta/recipes-extended/sudo/sudo_1.9.6p1.bb
+++ b/meta/recipes-extended/sudo/sudo_1.9.6p1.bb
@@ -47,6 +47,8 @@ do_install_append () {
 FILES_${PN}-dev += "${libdir}/${BPN}/lib*${SOLIBSDEV} ${libdir}/${BPN}/*.la \
                     ${libdir}/lib*${SOLIBSDEV} ${libdir}/*.la"
 
+CONFFILES:${PN}-lib = "${sysconfdir}/sudoers"
+
 SUDO_PACKAGES = "${PN}-sudo\
                  ${PN}-lib"
 


### PR DESCRIPTION
When OE-core commit 788c95c3bb8ede0d3d6a8f125743ac47c0b3f00e created the
`sudo-lib` subpackage, /etc/sudoers was moved from `sudo` to `sudo-lib`.
The commit didn't update the `CONFFILES:${PN}` assignment in sudo.inc,
however. So the `sudo` base package continued to advertise conffile
ownership of /etc/sudoers, though it did not contain it.

Move the CONFFILES assignment to the sudo.bb file, since it is
packaging-related. Change the package owner to the `sudo-lib`
subpackage, since it is the rightful file-owner.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>
Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
(cherry picked from commit 7d688f0ece8fa7e3118cde0c79bbcc56048a2bb5)
Rebased-by: Alex Stewart <alex.stewart@ni.com>

---

NI AZDO: [Task 1856146](https://dev.azure.com/ni/DevCentral/_workitems/edit/1856146)

# Testing
Rebuilt `sudo` with and without this change and verified that `/etc/sudoers` was added to the `sudo-lib` CONFFILES.

@ni/rtos 