### PR TITLE
mesa: enable gallium intel drivers when building for x86

### DIFF
--- a/meta/recipes-graphics/mesa/mesa.inc
+++ b/meta/recipes-graphics/mesa/mesa.inc
@@ -132,6 +132,9 @@ PACKAGECONFIG[v3d] = ""
 GALLIUMDRIVERS = "swrast"
 # gallium swrast was found to crash Xorg on startup in x32 qemu
 GALLIUMDRIVERS_x86-x32 = ""
+# Add crocus when 21.2 is out to the list below to support the full range of Intel GPUs
+GALLIUMDRIVERS_append_x86_class-target = ",i915,iris"
+GALLIUMDRIVERS_append_x86-64_class-target = ",i915,iris"
 
 GALLIUMDRIVERS_append ="${@bb.utils.contains('PACKAGECONFIG', 'etnaviv', ',etnaviv', '', d)}"
 GALLIUMDRIVERS_append ="${@bb.utils.contains('PACKAGECONFIG', 'freedreno', ',freedreno', '', d)}"

--- a/meta/recipes-graphics/mesa/mesa_21.0.3.bb
+++ b/meta/recipes-graphics/mesa/mesa_21.0.3.bb
@@ -1,4 +1,5 @@
 require ${BPN}.inc
 
-DRIDRIVERS_append_x86_class-target = ",r100,r200,nouveau,i965,i915"
-DRIDRIVERS_append_x86-64_class-target = ",r100,r200,nouveau,i965,i915"
+DRIDRIVERS_append_x86_class-target = ",r100,r200,nouveau,i965"
+DRIDRIVERS_append_x86-64_class-target = ",r100,r200,nouveau,i965"
+


### PR DESCRIPTION
### Description

Newer generation of Intel integrated graphic chipsets are only supported by the Iris OpenGL driver for MESA. Without Iris, hardware acceleration will not be enabled. [azdo bug link](https://ni.visualstudio.com/DevCentral/_workitems/edit/1862544/)

### Implementation

Cherry-pick commit from OE upstream that enables the Iris support in MESA. There was a merge conflict due to upstream having renamed `mesa_21.0.3.bb` file to a newer version.

### Testing

Pending testing on real hardware.

@ni/rtos 