### PR TITLE
pseudo: Fix handling of absolute links

### DIFF
--- a/meta/recipes-devtools/pseudo/pseudo_git.bb
+++ b/meta/recipes-devtools/pseudo/pseudo_git.bb
@@ -13,7 +13,7 @@ SRC_URI:append:class-nativesdk = " \
     file://older-glibc-symbols.patch"
 SRC_URI[prebuilt.sha256sum] = "ed9f456856e9d86359f169f46a70ad7be4190d6040282b84c8d97b99072485aa"
 
-SRCREV = "d34f2f6cedccf8488730001bcbde6bb7499f8814"
+SRCREV = "2b4b88eb513335b0ece55fe51854693d9b20de35"
 S = "${WORKDIR}/git"
 PV = "1.9.0+git${SRCPV}"
 


### PR DESCRIPTION
Update to a version of pseudo which has a fix for absolute links,
evaluating them from the chroot path.

Work Item: [#1902254](https://ni.visualstudio.com/DevCentral/_workitems/edit/1902254)

### Testing
Verified absolute links aren't deleted during image build with this version of `pseudo`

### Note
This is cherry picked from upstream master as it hasn't yet been merged to upstream hardknott ([PR here](https://lists.openembedded.org/g/openembedded-core/topic/hardknott_patch_pseudo/90293774?p=,,,20,0,0,0::recentpostdate/sticky,,,20,2,0,90293774,previd%3D1649262744601997252,nextid%3D1649245610973565557&previd=1649262744601997252&nextid=1649245610973565557)).