### PR TITLE
image_types: Remove leading './' in tar image archives

### DIFF
--- a/meta/classes/image_types.bbclass
+++ b/meta/classes/image_types.bbclass
@@ -110,7 +110,7 @@ IMAGE_CMD_squashfs-lz4 = "mksquashfs ${IMAGE_ROOTFS} ${IMGDEPLOYDIR}/${IMAGE_NAM
 
 IMAGE_CMD_TAR ?= "tar"
 # ignore return code 1 "file changed as we read it" as other tasks(e.g. do_image_wic) may be hardlinking rootfs
-IMAGE_CMD_tar = "${IMAGE_CMD_TAR} --sort=name --format=posix --numeric-owner -cf ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.tar -C ${IMAGE_ROOTFS} . || [ $? -eq 1 ]"
+IMAGE_CMD_tar = "${IMAGE_CMD_TAR} --sort=name --format=posix --numeric-owner --transform=s:'^./':: -cf ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.tar -C ${IMAGE_ROOTFS} . || [ $? -eq 1 ]"
 
 do_image_cpio[cleandirs] += "${WORKDIR}/cpio_append"
 IMAGE_CMD_cpio () {


### PR DESCRIPTION
The leading './' makes it difficult to provide relative paths to tar during the untar operation.
For example, `tar xvf --exclude=usr/bin` does not apply correctly to the files in the archive because they are prefixed with a './'. As an alternative to applying './' to all the exclude paths, remove the leading './' when creating the tar archive.

Notes:
- This change fixes azdo bug [1963519](https://ni.visualstudio.com/DevCentral/_boards/board/t/RTOS/Work%20Items/?workitem=1963519). Targets reconnect to the salt master after a hardknott image reinstallation.
- This is not a new problem in the archive. It has always existed and the --exclude options in the nisystemimage script have not been applied correctly. The issue has come up now because the new hardknott image contains a master.conf that tar installs over the existing master.conf in the old image. This problem did not exist in sumo because the sumo image did not contain a master.conf file. The file is installed to the image as part of a package in the hardknott image creation process.
- The alternative to this change is fixing the nisystemimage script. The fix looks like [this](https://github.com/shruthi-ravi/meta-nilrt/commit/1761e30d16786dcee0b952b69aac8a7552731b5c). The fix adds './' to the existing exclude paths and any additional paths provided in the cmd line. Additional changes to ninetcfgutil will also be required. These changes are not completely tested and are more risky to add at this time in the release.