### PR TITLE
opkg: upgrade to version 0.6.0

### DIFF
--- a/meta/recipes-devtools/opkg/opkg_0.6.0.bb
+++ b/meta/recipes-devtools/opkg/opkg_0.6.0.bb
@@ -18,7 +18,7 @@ SRC_URI = "http://downloads.yoctoproject.org/releases/${BPN}/${BPN}-${PV}.tar.gz
            file://run-ptest \
 "
 
-SRC_URI[sha256sum] = "559c3e1b893abaa1dd473ce3a9a5f7dd3f60ceb6cd14caaef76ddf0f7721ad1c"
+SRC_URI[sha256sum] = "56844722eff237daf14aa6e681436f3245213c5590ed0cda37a79df637ff3a4c"
 
 # This needs to be before ptest inherit, otherwise all ptest files end packaged
 # in libopkg package if OPKGLIBDIR == libdir, because default


### PR DESCRIPTION
Release Notes for 0.6.0:

http://downloads.yoctoproject.org/releases/opkg/opkg-0.6.0.release-notes

Signed-off-by: Alex Stewart <alex.stewart@ni.com>
Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
(cherry picked from commit 1e08da6a43876677ae4481156ce1d7177b77264d)

# Testing
* Built the core feeds and `nilrt-recovery-media` with this change and used it to provision a NILRT VM. Booted the VM and verified that the image and opkg was well-formed, that opkg was updated, and that I could perform opkg operations as normal.

# Maintainership
I'll merge this PR into `nilrt/master/hardknott` only after I have created a 22.5 release branch. I won't cherry-pick this into the release branch. I'm also not intending to upgrade opkg in the sumo mainline, since there is no motive to do so.