### PR TITLE
Create locale directory when installing locales.

### DIFF
--- a/meta/classes/libc-package.bbclass
+++ b/meta/classes/libc-package.bbclass
@@ -45,6 +45,12 @@ PACKAGE_NO_GCONV ?= "0"
 OVERRIDES_append = ":${TARGET_ARCH}-${TARGET_OS}"
 
 locale_base_postinst_ontarget() {
+#!/bin/sh
+
+if [ "x$D" != "x" ]; then
+	exit 1
+fi
+mkdir -p /usr/lib/locale
 localedef --inputfile=${datadir}/i18n/locales/%s --charmap=%s %s
 }
 


### PR DESCRIPTION
Cherry-pick hack from 68a03159 to ensure the /usr/lib/locale
directory gets created.

With the revert to glibc 2.24, cross-localedef isn't playing
nicely and glibc-binary-localedata-* packages aren't being
generated. This change pulls back a hack to get on-target
locale generation working again.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

Prior to this fix, the locale-base-* ipks would return the following errors when running their postinst scripts. 
```
Configuring locale-base-ja-jp.windows-31j.
cannot create temporary file: /usr/lib/locale/locale-archive.rGVx1O: No such file or directory
 * pkg_run_script: package "locale-base-ja-jp.windows-31j" postinst script returned status 1.
 * opkg_configure: locale-base-ja-jp.windows-31j.postinst returned 1.
 ```

AzDO Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/2022245/

# Testing:
Confirmed glibc-locale built with the changes locally. 