### PR TITLE
glibc: do_stash_locale must not delete files from ${D}

### DIFF
--- a/meta/recipes-core/glibc/glibc-package.inc
+++ b/meta/recipes-core/glibc/glibc-package.inc
@@ -140,7 +140,6 @@ do_stash_locale () {
 		mv ${D}${datadir}/i18n ${dest}${datadir}
 	fi
 	cp -fpPR ${D}${datadir}/* ${dest}${datadir}
-	rm -rf ${D}${datadir}/locale/
 	cp -fpPR ${WORKDIR}/SUPPORTED ${dest}
 
 	target=${dest}/scripts


### PR DESCRIPTION
Cherry-picked change from f18817f5340d06f7b4bb846a83b48731a1b9c4bc
and re-applied to the current version of the file. This should
resolve the pseudo path mismatch errors for files in the
`/usr/share/locale` directory.

Fixes azdo bug [2022359](https://ni.visualstudio.com/DevCentral/_workitems/edit/2022359).

### Testing
Did not run into the pseudo path mismatch error with this change. I cleaned the glibc recipe cache and re-ran the build several times.