### PR TITLE
package_manager: Don't pipe stderr to stdout when writing stdout to s…

### DIFF
--- a/meta/lib/oe/package_manager.py
+++ b/meta/lib/oe/package_manager.py
@@ -1334,7 +1334,7 @@ class OpkgPM(OpkgDpkgPM):
                 pkg_info = cmd + pkg
 
                 try:
-                    output = subprocess.check_output(pkg_info.split(), stderr=subprocess.STDOUT).strip().decode("utf-8")
+                    output = subprocess.check_output(pkg_info.split()).strip().decode("utf-8")
                 except subprocess.CalledProcessError as e:
                     bb.fatal("Cannot get package info. Command '%s' "
                              "returned %d:\n%s" % (pkg_info, e.returncode, e.output.decode("utf-8")))


### PR DESCRIPTION
…tatus file

The status file can contain clobbered text like:
`Package: gnupg-lic 
Version: 2.2.4-r0.4 * rm_r: Failed to open dir /home/rfmibuild/myagent/_work/_r/0/src/rtos/rtoslegacyd/NIOpenEmbedded/objects/build.xilinx-zynq/tmp-glibc/work/xilinx-zynq-nilrt-linux-gnueabi/niconsole-dkms-image/1.0-r0/temp/ipktemp//opkg-2yg8jO: No such file or directory. 
Status: deinstall hold not-installed`

### Testing

I can reproduce the problem consistently on an rfmibuild test server without the related opkg [patch](https://github.com/ni/meta-nilrt/commit/c80c21a41959b55c3be44043b2601588e6270e86). After the oe-core fix, I can no longer reproduce the issue.

### Notes

This would be the longer term fix for related azdo bug [1995116](https://ni.visualstudio.com/DevCentral/_workitems/edit/1995116).
Only the -lic packages were affected because it looks like OE calls `handle_bad_recommendations()` on all the -lic packages before installing anything else in the rootfs. Therefore, the status file is first created by this function with the clobbered version.