### PR TITLE
libnsl2: Fixes to coexist with glibc-2.24's libnsl

### DIFF
--- a/meta/recipes-extended/libnsl/files/libnsl2_libs.conf
+++ b/meta/recipes-extended/libnsl/files/libnsl2_libs.conf
@@ -1,0 +1,1 @@
+/usr/lib/nsl

--- a/meta/recipes-extended/libnsl/libnsl2_git.bb
+++ b/meta/recipes-extended/libnsl/libnsl2_git.bb
@@ -15,6 +15,7 @@ PV = "1.3.0"
 SRCREV = "fbad7b36acaa89a54023930af70805649f962999"
 
 SRC_URI = "git://github.com/thkukuk/libnsl;branch=master;protocol=https \
+           file://libnsl2_libs.conf \
           "
 
 S = "${WORKDIR}/git"
@@ -27,8 +28,11 @@ EXTRA_OECONF += "--libdir=${libdir}/nsl --includedir=${includedir}/nsl"
 do_install_append() {
 	install -d ${D}${libdir}
 	mv ${D}${libdir}/nsl/pkgconfig ${D}${libdir}
+
+	install -d ${D}${sysconfdir}/ld.so.conf.d/
+	install -m 0644 ${WORKDIR}/libnsl2_libs.conf ${D}${sysconfdir}/ld.so.conf.d/
 }
 
-FILES_${PN} += "${libdir}/nsl/*.so.*"
+FILES_${PN} += "${libdir}/nsl/*.so.* ${sysconfdir}/ld.so.conf.d/libnsl2_libs.conf"
 FILES_${PN}-dev += "${includedir}/nsl ${libdir}/nsl/*.so"
 FILES_${PN}-staticdev += "${libdir}/nsl/*.a"


### PR DESCRIPTION
After glibc downgrade to 2.24, libnsl2 libraries were moved into
/usr/lib/nsl/ which isn't present in ld search path. This causes
binaries that depend on libnsl.so.2 to not work. So adding /usr/lib/nsl
to ld search path.

### Testing
Locally built BSI, installed to a target and verified `ypcat` works (previously it didn't work because `libnsl.so.2` wasn't in ld search path).

### Notes
Ideally we would have liked to have all recipes use `libnsl.so.2` as that is the latest version. But many recipes (mainly in extras feed) don't have explicit dependency on `libnsl2` and/or don't use `pkg-config` to find `libnsl2` compiler options and so end up linking with glibc's `libnsl.so.1`.

e.g., `libauth-samba4` in extras feed doesn't have dependency on `libnsl2` so it uses `libnsl.so.1` from glibc.

Another example is `python3` - even though it depends on `libnsl2` and `pkg-config`, it does not use `pkgconfig` to get nsl compiler options to build its `nsl` module - it manually searches standard include, library paths ([ref](https://github.com/python/cpython/blob/3.9/setup.py#L2448)) and so ends up using `libnsl.so.1`. However, the python `nis` module is a very thin wrapper that calls directly into underlying `libnsl.so`, so it using `libnsl.so.1` instead of `libnsl.so.2` should be ok.

But most all other recipes that have explicit dependency on `libnsl2`, use `pkgconfig` correctly and so link against `libnsl.so.2`.

We considered having `/usr/lib/libnsl.so` point to `libnsl.so.2` so that users compiling binaries that depend on nsl but not using `pkgconfig` end up linking against `libnsl.so.2`, but discarded it since `libnsl2`'s `rpcsvc` files (that are presumably required to build binaries) are in `/usr/include/nsl/rpcsvc` - which is not in standard include search path, but glibc's `rpcsvc` files are in the standard path `/usr/include/rpcsvc`, so this would have caused users to compile their binary with glibc's `rpcsvc` files but link against `libnsl.so.2` - which is probably not good.

Users compiling with `libnsl` by using `pkgconfig` will end up with the correct paths for `rpcsvc` files and `libnsl.so.2` though.
