### PR TITLE
libc-package: Fix output name of localedef

### DIFF
--- a/meta/classes/libc-package.bbclass
+++ b/meta/classes/libc-package.bbclass
@@ -219,9 +219,9 @@ python package_do_split_gconvs () {
         d.setVar('RDEPENDS_%s' % pkgname, '%slocaledef %s-localedata-%s %s-charmap-%s' % \
         (mlprefix, mlprefix+bpn, legitimize_package_name(locale), mlprefix+bpn, legitimize_package_name(encoding)))
         d.setVar('pkg_postinst_ontarget_%s' % pkgname, d.getVar('locale_base_postinst_ontarget') \
-        % (locale, encoding, locale))
+        % (locale, encoding, name))
         d.setVar('pkg_postrm_%s' % pkgname, d.getVar('locale_base_postrm') % \
-        (locale, encoding, locale))
+        (locale, encoding, name))
 
     def output_locale_binary_rdepends(name, pkgname, locale, encoding):
         dep = legitimize_package_name('%s-binary-localedata-%s' % (bpn, name))


### PR DESCRIPTION
locale packages with different encoding but same locale name run
localedef with same name in their postinst. So if more than one of those
packages is installed, the last running postinst will override the
charmap for previously installed locales.

So change the output path to be the same as package name.

Azure Work Item: [#2038278](https://ni.visualstudio.com/DevCentral/_workitems/edit/2038278)

### Testing
Locally built BSI and verified that charmap for locales is as expected


```
$ for i in `locale -a`; do echo $i " - " `LC_ALL=$i locale charmap`; done 

C  -  ANSI_X3.4-1968
CP932  -  WINDOWS-31J
CP936  -  CP936
en_US  -  UTF-8
en_US.iso88591  -  ISO-8859-1
en_US.utf8  -  UTF-8
ja_JP.windows31j  -  WINDOWS-31J
L1  -  ISO-8859-1
POSIX  -  ANSI_X3.4-1968
zh_CN.cp936  -  CP936
```

Verified that `mbstowcs` doesn't error with character `ö` when `LANG=L1`.

### Note
After this fix, `ja_JP` and `zn_CN` locales no longer exist (`ja_JP.windows31j`, `zh_CN.cp936` do), but I think this is ok since we only refer to these longer names [locales.alias](https://github.com/ni/meta-nilrt/blob/nilrt/22.5/hardknott/recipes-core/glibc/glibc/alias-custom-locales.patch)

~~@ maintainers: Please don't merge this yet, I saw a seemingly unrelated build error that I had to workaround - need to determine if it is due to this change~~ - this is no longer a concern, build works fine with right container.