### PR TITLE
libc-package: Fix output name of localedef

### DIFF
--- a/meta/classes/libc-package.bbclass
+++ b/meta/classes/libc-package.bbclass
@@ -213,9 +213,9 @@ python package_do_split_gconvs () {
         d.setVar('RDEPENDS_%s' % pkgname, '%slocaledef %s-localedata-%s %s-charmap-%s' % \
         (mlprefix, mlprefix+bpn, legitimize_package_name(locale), mlprefix+bpn, legitimize_package_name(encoding)))
         d.setVar('pkg_postinst_ontarget_%s' % pkgname, d.getVar('locale_base_postinst_ontarget') \
-        % (locale, encoding, locale))
+        % (locale, encoding, name))
         d.setVar('pkg_postrm_%s' % pkgname, d.getVar('locale_base_postrm') % \
-        (locale, encoding, locale))
+        (locale, encoding, name))
 
     def output_locale_binary_rdepends(name, pkgname, locale, encoding):
         dep = legitimize_package_name('%s-binary-localedata-%s' % (bpn, name))


### PR DESCRIPTION
locale packages with different encoding but same locale name run
localedef with same name in their postinst. So if more than one of those
packages is installed, the last running postinst will override the
charmap for previously installed locales.

So change the output path to be the same as package name.

(cherry picked from commit 08e724c7db6369d6f627cf592ad09ab5dd316e1a)