### PR TITLE
Revert "Revert "libpam: deny all services for the OTHER entries""

### DIFF
--- a/meta/recipes-extended/pam/libpam/pam.d/other
+++ b/meta/recipes-extended/pam/libpam/pam.d/other
@@ -6,22 +6,19 @@
 #pam_open_session, the session module out of /etc/pam.d/other is
 #used.  
 
-#If you really want nothing to happen then use pam_permit.so or
-#pam_deny.so as appropriate.
-
 # We use pam_warn.so to generate syslog notes that the 'other'
 #fallback rules are being used (as a hint to suggest you should setup
-#specific PAM rules for the service and aid to debugging). We then 
-#fall back to the system default in /etc/pam.d/common-*
+#specific PAM rules for the service and aid to debugging). Then to be
+#secure, deny access to all services by default. 
 
 auth       required     pam_warn.so
-auth       include      common-auth
+auth       required     pam_deny.so
 
 account    required     pam_warn.so
-account    include      common-account
+account    required     pam_deny.so
 
 password   required     pam_warn.so
-password   include      common-password
+password   required     pam_deny.so
 
 session    required     pam_warn.so
-session    include      common-session
+session    required     pam_deny.so


### PR DESCRIPTION
This reverts commit 03f3cbc5af79be477ee2dd997d8931561fbdbef5.

NI LinuxRT prefers to use the older pam `other` file provided by
OE-core. But there is no reason that OE-core would upstream our
preference.

Remove this file from OE-core, so that it can be migrated to meta-nilrt.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

Natinst AZDO ID: [#1580104](https://dev.azure.com/ni/DevCentral/_workitems/edit/1580104)

# Testing
Nome