### PR TITLE
Revert "openembedded-core: Update umountnfs update-rc.d rule to stop."

### DIFF
--- a/meta/recipes-core/initscripts/initscripts_1.0.bb
+++ b/meta/recipes-core/initscripts/initscripts_1.0.bb
@@ -131,7 +131,7 @@ do_install () {
 	update-rc.d -r ${D} rmnologin.sh start 99 2 3 4 5 .
 	update-rc.d -r ${D} sendsigs start 20 0 6 .
 	update-rc.d -r ${D} urandom start 38 S 0 6 .
-	update-rc.d -r ${D} umountnfs.sh stop 31 0 1 6 .
+	update-rc.d -r ${D} umountnfs.sh start 31 0 1 6 .
 	update-rc.d -r ${D} umountfs start 40 0 6 .
 	update-rc.d -r ${D} reboot start 90 6 .
 	update-rc.d -r ${D} halt start 90 0 .


### PR DESCRIPTION
This reverts commit 16431c20b0e87084f0bf8728f2df8214dffa87d5.

The umountnfs initscript runlevel operation in this commit is
NI-specific and should be moved to meta-nilrt.

Remove the commit from OE-core so that it can be migrated.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

Natinst AZDO: [#1580104](https://dev.azure.com/ni/DevCentral/_workitems/edit/1580104)

# Testing
None.