### PR TITLE
gcc: Shrink default packaging

### DIFF
--- a/meta/recipes-devtools/gcc/gcc-target.inc
+++ b/meta/recipes-devtools/gcc/gcc-target.inc
@@ -116,6 +116,7 @@ FILES_gcov-symlinks = "${bindir}/gcov \
 FILES_g++ = "\
     ${bindir}/${TARGET_PREFIX}g++* \
     ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/cc1plus \
+    ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/g++* \
 "
 FILES_g++-symlinks = "\
     ${bindir}/c++ \

--- a/meta/recipes-devtools/gcc/gcc-target.inc
+++ b/meta/recipes-devtools/gcc/gcc-target.inc
@@ -172,6 +172,7 @@ do_install () {
 
 	# We don't care about the gcc-<version> ones for this
 	rm -f *gcc-?.?*
+	rm -f *gcc-??.?*
 
 	# We use libiberty from binutils
 	find ${D}${libdir} -name libiberty.a | xargs rm -f

--- a/meta/recipes-devtools/gcc/gcc-target.inc
+++ b/meta/recipes-devtools/gcc/gcc-target.inc
@@ -34,11 +34,11 @@ PACKAGES = "\
     ${PN}-doc \
     ${PN}-dev \
     ${PN}-dbg \
+    ${PN}-lto-dump \
 "
 
 FILES_${PN} = "\
     ${bindir}/${TARGET_PREFIX}gcc* \
-    ${bindir}/${TARGET_PREFIX}lto* \
     ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/collect2* \
     ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/cc1plus \
     ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/lto* \
@@ -132,6 +132,9 @@ FILES_${PN}-doc = "\
     ${infodir} \
     ${mandir} \
     ${gcclibdir}/${TARGET_SYS}/${BINV}/include/README \
+"
+FILES_${PN}-lto-dump = "\
+    ${bindir}/${TARGET_PREFIX}lto* \
 "
 
 do_compile () {


### PR DESCRIPTION
Shrink the size of the gcc install that is included in the base image for academic