### PR TITLE
[academic] Remove -only suffix from gcc license specifier

### DIFF
--- a/meta/recipes-devtools/gcc/gcc-12.1.inc
+++ b/meta/recipes-devtools/gcc/gcc-12.1.inc
@@ -13,7 +13,7 @@ FILESEXTRAPATHS =. "${FILE_DIRNAME}/gcc:${FILE_DIRNAME}/gcc/backport:"
 DEPENDS =+ "mpfr gmp libmpc zlib flex-native"
 NATIVEDEPS = "mpfr-native gmp-native libmpc-native zlib-native flex-native zstd-native"
 
-LICENSE = "GPL-3.0-with-GCC-exception & GPL-3.0-only"
+LICENSE = "GPL-3.0-with-GCC-exception & GPL-3.0"
 
 LIC_FILES_CHKSUM = "\
     file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552 \


### PR DESCRIPTION
As mentioned in [AB#2163828](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2163828), building various gcc recipes cause warnings about finding a matching license. This is due to upstream changes to use "-only" and "-or-later" license suffixes.

As mentioned in #72, the academic branch does not need to keep up with the upstream mainline, so a simple fix for the license compatibility is preferable to a large change to touch all the license uses to use the suffixes.