### PR TITLE
Revert "package_manager.py: Add PACKAGE_ENABLE_FILELIST option to Opk…

### DIFF
--- a/meta/lib/oe/package_manager.py
+++ b/meta/lib/oe/package_manager.py
@@ -148,8 +148,6 @@ class OpkgIndexer(Indexer):
         else:
             signer = None
 
-        enable_filelist = bb.utils.to_boolean(self.d.getVar('PACKAGE_ENABLE_FILELIST', True) or "False")
-
         if not os.path.exists(os.path.join(self.deploy_dir, "Packages")):
             open(os.path.join(self.deploy_dir, "Packages"), "w").close()
 
@@ -164,18 +162,14 @@ class OpkgIndexer(Indexer):
                 pkgs_dir = os.path.join(self.deploy_dir, arch)
                 pkgs_file = os.path.join(pkgs_dir, "Packages")
 
-                filelist_cmd = ""
-                if enable_filelist:
-                    filelist_cmd = '-l %s.filelist' % (pkgs_file)
-
                 if not os.path.isdir(pkgs_dir):
                     continue
 
                 if not os.path.exists(pkgs_file):
                     open(pkgs_file, "w").close()
 
-                index_cmds.add('%s --checksum md5 --checksum sha256 -r %s -p %s -m %s %s' %
-                                  (opkg_index_cmd, pkgs_file, pkgs_file, filelist_cmd, pkgs_dir))
+                index_cmds.add('%s --checksum md5 --checksum sha256 -r %s -p %s -m %s' %
+                                  (opkg_index_cmd, pkgs_file, pkgs_file, pkgs_dir))
 
                 index_sign_files.add(pkgs_file)
 


### PR DESCRIPTION
There don't seem to be any uses of Packages.filelist. So removing PACKAGE_ENABLE_FILELIST implementation to save build time.

This reverts commit 8633a85c3200a89c9231c012b59871843b13a739.

### Testing
Ran `bitbake package-index` without issues.
Hardknott [had this revert](https://github.com/ni/openembedded-core/pull/70) for a few weeks without issues. 