### PR TITLE
fixup! package_manager: Fix erroneous assignments

### DIFF
--- a/meta/lib/oe/package_manager/ipk/__init__.py
+++ b/meta/lib/oe/package_manager/ipk/__init__.py
@@ -168,7 +168,6 @@ class OpkgPM(OpkgDpkgPM):
             self.deploy_dir = self.d.getVar("DEPLOY_DIR_IPK")
         else:
             self.deploy_dir = oe.path.join(self.d.getVar('WORKDIR'), ipk_repo_workdir)
-        self.deploy_dir = oe.path.join(self.d.getVar('WORKDIR'), ipk_repo_workdir)
         self.deploy_lock_file = os.path.join(self.deploy_dir, "deploy.lock")
         self.opkg_cmd = bb.utils.which(os.getenv('PATH'), "opkg")
         self.opkg_args = "--volatile-cache -f %s -t %s -o %s " % (self.config_file, self.d.expand('${T}/ipktemp/') ,target_rootfs)
@@ -177,9 +176,6 @@ class OpkgPM(OpkgDpkgPM):
         if not d.getVar('BUILD_IMAGES_FROM_FEEDS'):
             if prepare_index:
                 create_packages_dir(self.d, self.deploy_dir, d.getVar("DEPLOY_DIR_IPK"), "package_write_ipk", filterbydependencies)
-
-        if prepare_index:
-            create_packages_dir(self.d, self.deploy_dir, d.getVar("DEPLOY_DIR_IPK"), "package_write_ipk", filterbydependencies)
 
         self.opkg_dir = oe.path.join(target_rootfs, self.d.getVar('OPKGLIBDIR'), "opkg")
         bb.utils.mkdirhier(self.opkg_dir)


### PR DESCRIPTION
When BUILD_IMAGES_FROM_FEEDS is enabled, the package manager's deploy_dir should be set to DEPLOY_DIR_IPK, and directory creation should be disabled. During the hardknott rebase, commit 8404b1a accidentally overwrote these assumptions.