### PR TITLE
meta-toolchain: Disable BUILD_IMAGES_FROM_FEEDS

### DIFF
--- a/meta/recipes-core/meta/meta-toolchain.bb
+++ b/meta/recipes-core/meta/meta-toolchain.bb
@@ -3,4 +3,13 @@ LICENSE = "MIT"
 
 PR = "r7"
 
+python() {
+    # It does not make sense to build a toolchain when BUILD_IMAGES_FROM_FEEDS
+    # is enabled. The SDK packages for the given SDK_MACHINE are built and
+    # indexed as part of this recipe, and are not available in any feed.
+    if d.getVar("BUILD_IMAGES_FROM_FEEDS"):
+        bb.warn("BUILD_IMAGES_FROM_FEEDS should be turned off when building a toolchain. Disabling.")
+    d.setVar("BUILD_IMAGES_FROM_FEEDS", 0)
+}
+
 inherit populate_sdk


### PR DESCRIPTION
It does not make sense to build a toolchain when BUILD_IMAGES_FROM_FEEDS is enabled. The SDK packages for the given SDK_MACHINE are built and indexed as part of this recipe, and are not available in any feed. Therefore, print a warning if BUILD_IMAGES_FROM_FEEDS is enabled and disable it.

Verified that the warning was printed at build time. Also, verified that BUILD_IMAGES_FROM_FEEDS is set to 0.