### PR TITLE
binutils-cross-canadian: Add lib*.a files to the staticdev package

### DIFF
--- a/meta/recipes-devtools/binutils/binutils-cross-canadian.inc
+++ b/meta/recipes-devtools/binutils/binutils-cross-canadian.inc
@@ -30,3 +30,5 @@ do_install () {
 }
 
 BBCLASSEXTEND = ""
+
+FILES_${PN}-staticdev:append = " ${libdir}/bfd-plugins/lib*.a"


### PR DESCRIPTION
Built the `meta-toolchain` recipe for x86_64-mingw32 SDKMACHINE successfully with this change.

AzDO [2105299](https://ni.visualstudio.com/DevCentral/_workitems/edit/2105299)