### PR TITLE
[kirkstone] license.bbclass: Revert removal of adding *-lic ipks to RRECOMMENDS

### DIFF
--- a/meta/classes/license.bbclass
+++ b/meta/classes/license.bbclass
@@ -64,6 +64,14 @@ def add_package_and_files(d):
         # first in PACKAGES to be sure that nothing else gets LICENSE_FILES_DIRECTORY
         d.setVar('PACKAGES', "%s %s" % (pn_lic, packages))
         d.setVar('FILES:' + pn_lic, files)
+    for pn in packages.split():
+        if pn == pn_lic:
+            continue
+        rrecommends_pn = d.getVar('RRECOMMENDS_' + pn)
+        if rrecommends_pn:
+            d.setVar('RRECOMMENDS_' + pn, "%s %s" % (pn_lic, rrecommends_pn))
+        else:
+            d.setVar('RRECOMMENDS_' + pn, "%s" % (pn_lic))
 
 def copy_license_files(lic_files_paths, destdir):
     import shutil

--- a/meta/classes/license.bbclass
+++ b/meta/classes/license.bbclass
@@ -67,11 +67,11 @@ def add_package_and_files(d):
     for pn in packages.split():
         if pn == pn_lic:
             continue
-        rrecommends_pn = d.getVar('RRECOMMENDS_' + pn)
+        rrecommends_pn = d.getVar('RRECOMMENDS:' + pn)
         if rrecommends_pn:
-            d.setVar('RRECOMMENDS_' + pn, "%s %s" % (pn_lic, rrecommends_pn))
+            d.setVar('RRECOMMENDS:' + pn, "%s %s" % (pn_lic, rrecommends_pn))
         else:
-            d.setVar('RRECOMMENDS_' + pn, "%s" % (pn_lic))
+            d.setVar('RRECOMMENDS:' + pn, "%s" % (pn_lic))
 
 def copy_license_files(lic_files_paths, destdir):
     import shutil


### PR DESCRIPTION
Upstream removed the functionality that added *-lic ipks as RRECOMMENDS to all PACKAGES for a recipe when LICENSE_CREATE_PACKAGE is in use as it didn't apply to PACKAGES_DYNAMIC. This reverts that change as without it packages don't install their *-lic files when installed from feeds.

AzDO Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/2104910/

**Note:** I'll create a follow-up work item to see about upstreaming this. 

## Testing:
Built packagefeed-ni-core and confirmed it worked with the change added back. Checked a package to ensure it included the expected RRECOMMENDS. 