### PR TITLE
meta-toolchain: Disable BUILD_IMAGES_FROM_FEED before the populate_sd…

### DIFF
--- a/meta/recipes-core/meta/meta-toolchain.bb
+++ b/meta/recipes-core/meta/meta-toolchain.bb
@@ -3,7 +3,7 @@ LICENSE = "MIT"
 
 PR = "r7"
 
-python() {
+do_populate_sdk:prepend() {
     # It does not make sense to build a toolchain when BUILD_IMAGES_FROM_FEEDS
     # is enabled. The SDK packages for the given SDK_MACHINE are built and
     # indexed as part of this recipe, and are not available in any feed.


### PR DESCRIPTION
…k task

Instead of disabling the configuration in an anonymous function, disable only at the time of populate_sdk. This ensures that the warning is not evaluated when parsing the recipes for all builds.

### Testing
Verified that the toolchain builds successfully, after printing the warning, and that the warning is not printed while building other recipes.