### PR TITLE
[kirkstone] insane: Use new syntax :${PN} to namespace native-last

### DIFF
--- a/meta/classes/insane.bbclass
+++ b/meta/classes/insane.bbclass
@@ -1406,7 +1406,7 @@ python () {
     for i in issues:
         oe.qa.handle_error("pkgvarcheck", "%s: Variable %s is set as not being package specific, please fix this." % (d.getVar("FILE"), i), d)
 
-    if 'native-last' not in (d.getVar(d.expand('INSANE_SKIP_${PN}')) or "").split():
+    if 'native-last' not in (d.getVar(d.expand('INSANE_SKIP:${PN}')) or "").split():
         for native_class in ['native', 'nativesdk']:
             if bb.data.inherits_class(native_class, d):
 


### PR DESCRIPTION
insane.bbclass was modified in 8aee084f to namespace native-last using _${PN}. This updates the syntax to the new :${PN} format to prevent the warning from occuring in updated recipes such as rauc-native.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

AzDO Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/2222214

## Testing:
Built `rauc-native` after running `bitbake rauc-native -c cleanall` and confirmed the warning no longer appears. 