### PR TITLE
jitterentropy-rngd_1.0.8.bb: added master branch to uri

### DIFF
--- a/meta/recipes-support/jitterentropy/jitterentropy-rngd_1.0.8.bb
+++ b/meta/recipes-support/jitterentropy/jitterentropy-rngd_1.0.8.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=e52365752b36cfcd7f9601d80de7d8c6 \
                     file://COPYING.gplv2;md5=eb723b61539feef013de476e68b5c50a \
 "
 
-SRC_URI = "git://github.com/smuellerDD/jitterentropy-rngd.git;protocol=https \
+SRC_URI = "git://github.com/smuellerDD/jitterentropy-rngd.git;protocol=https;branch=master \
            file://0001-Makefile-support-cross-compiling.patch \
            file://init-jitterentropy-rngd \
 "


### PR DESCRIPTION
This file has a git uri that throws a warning for not specifying a branch.
There is only one branch, so to remove the warning, we can simply add "branch=master" which should be the same behavior as not specifying a branch anyway.