### PR TITLE
[kirkstone] lsof: add update-alternatives logic

### DIFF
--- a/meta/recipes-extended/lsof/lsof_4.94.0.bb
+++ b/meta/recipes-extended/lsof/lsof_4.94.0.bb
@@ -19,6 +19,15 @@ SRCREV = "005e014e1abdadb2493d8b3ce87b37a2c0a2351d"
 
 S = "${WORKDIR}/git"
 
+
+inherit update-alternatives
+
+ALTERNATIVE_${PN} = "lsof"
+ALTERNATIVE_LINK_NAME[lsof] = "${sbindir}/lsof"
+# Make our priority higher than busybox
+ALTERNATIVE_PRIORITY = "100"
+
+
 export LSOF_INCLUDE = "${STAGING_INCDIR}"
 
 do_configure () {


### PR DESCRIPTION
Some distributions (NI LinuxRT) provide both busybox-lsof and full-featured lsof implementations. When users install the full-featured lsof package, the full-binary fails to replace the bbox-binary in PATH, because `lsof` contains no update-alternatives logic.

Inherit the update-alternatives bbclass and assert that the full-featured lsof package has higher priority than the busybox implementation.

Co-Authored-By: Kyle Roeschley <kyle.roeschley@ni.com>
Signed-off-by: Alex Stewart <alex.stewart@ni.com>
Signed-off-by: Alexandre Belloni <alexandre.belloni@bootlin.com>
(cherry picked from commit e2893fa692a6e91eee09fc04c8c03fe27c718a58)
Signed-off-by: Alex Stewart <alex.stewart@ni.com>

NI AZDO: https://dev.azure.com/ni/DevCentral/_boards/board/t/RTOS/Work%20Items/?workitem=1131291

# Testing
* Built `lsof` with this change and installed it to a hardknott image. Confirmed that the `lsof` impelementation in PATH is correctly set to the full-featured-binary.
* When `opkg remove lsof` is called, the binary is correctly reset to the bbox implementation.

# Meta
* This behavior exists in the hardknott mainline as well. But since this is technical debt rather than a reported bug, I'm fine just pulling it into kirkstone.