### PR TITLE
ptest-packagelists: add run-postinsts to ptest list

### DIFF
--- a/meta/conf/distro/include/ptest-packagelists.inc
+++ b/meta/conf/distro/include/ptest-packagelists.inc
@@ -112,6 +112,7 @@ PTESTS_PROBLEMS:append:riscv64 = "valgrind-ptest"
 #    numactl-ptest \ # qemu not (yet) configured for numa; all tests are skipped
 #    libseccomp-ptest \ #  tests failed: 38; add to slow tests once addressed
 #    python3-numpy-ptest \ # requires even more RAM and (possibly) disk space; multiple failures
+#    run-postinsts-ptest \ # depends upon bash-ptest which is non-deterministic by design
 
 PTESTS_PROBLEMS = "\
     ruby-ptest \
@@ -125,4 +126,5 @@ PTESTS_PROBLEMS = "\
     libseccomp-ptest \
     numactl-ptest \
     python3-numpy-ptest \
+    run-postinsts-ptest \
 "


### PR DESCRIPTION
In kirkstone, ptests are listed in ptest-packagelists.

This creates a warning as run-postinsts depends upon the bash ptest but is not included in the ptest-packagelists.inc file:

```
WARNING: run-postinsts-1.0-r10 do_package_qa: QA Issue: supports ptests but is not included in oe-core's ptest-packagelists.inc [missing-ptest]
```

You can squash the warning by adding it