### PR TITLE
[kirkstone] opkg: upgrade to version 0.6.1

### DIFF
--- a/meta/recipes-devtools/opkg/opkg_0.6.1.bb
+++ b/meta/recipes-devtools/opkg/opkg_0.6.1.bb
@@ -18,7 +18,7 @@ SRC_URI = "http://downloads.yoctoproject.org/releases/${BPN}/${BPN}-${PV}.tar.gz
            file://run-ptest \
 "
 
-SRC_URI[sha256sum] = "56844722eff237daf14aa6e681436f3245213c5590ed0cda37a79df637ff3a4c"
+SRC_URI[sha256sum] = "e87fccb575c64d3ac0559444016a2795f12125986a0da896bab97c4a1a2f1b2a"
 
 # This needs to be before ptest inherit, otherwise all ptest files end packaged
 # in libopkg package if OPKGLIBDIR == libdir, because default


### PR DESCRIPTION
Opkg 0.6.1 Changes:
- Opkg will no longer complain when trying to clean up the temporary directory, if the directory does not exist.
- Fixed a SEGFAULT when parsing package indexes with invalid `Size` or `Installed-Size` fields. These indexes will now produce a comprehensible error.
- Fixed an inconsistecy in .list generation where files would sometimes be entered with/without a trailing slash. The trailng slash should now always be removed.
- Fixed [a bug](https://bugzilla.yoctoproject.org/show_bug.cgi?id=10461) in package removal, where empty common directories would be left on disk, even after all owning packages were removed.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>
Signed-off-by: Alexandre Belloni <alexandre.belloni@bootlin.com>
(cherry picked from commit 037ff235fa8e369c0eac9f84cb82c9eaffba85f3)
Signed-off-by: Alex Stewart <alex.stewart@ni.com>

NI AZDO: https://dev.azure.com/ni/DevCentral/_workitems/edit/2061435

# Testing
* `bitbake opkg` in the kirkstone mainline and confirmed that it builds.
* Ran a `core-image-minimal` rootfs build in OE-core with opkg 0.6.1 and confirmed that do_rootfs functions correctly.
* We will get additional runtime testing as a consequence of kirkstone client testing in 23C1.

# Meta
Nothing in this opkg release is needed for the 23Q1 or 23Q2 releases, so I'm not planning to cherry-pick this into hardknott unless we intentionally decide otherwise.