### PR TITLE
Add patch to un-uniquify elfutils ptest output

### DIFF
--- a/meta/recipes-devtools/elfutils/elfutils_0.183.bb
+++ b/meta/recipes-devtools/elfutils/elfutils_0.183.bb
@@ -22,6 +22,7 @@ SRC_URI = "https://sourceware.org/elfutils/ftp/${PV}/${BP}.tar.bz2 \
            file://ptest.patch \
            file://0001-tests-Makefile.am-compile-test_nlist-with-standard-C.patch \
            file://0001-add-support-for-ipkg-to-debuginfod.cxx.patch \
+           file://0001-Don-t-print-PID-uniquified-core-file-for-skipped-tes.patch \
            "
 SRC_URI_append_libc-musl = " \
            file://0002-musl-libs.patch \

--- a/meta/recipes-devtools/elfutils/files/0001-Don-t-print-PID-uniquified-core-file-for-skipped-tes.patch
+++ b/meta/recipes-devtools/elfutils/files/0001-Don-t-print-PID-uniquified-core-file-for-skipped-tes.patch
@@ -1,0 +1,32 @@
+From bb88dc47fdfda61e2120e95e984d05bf0ace308f Mon Sep 17 00:00:00 2001
+From: Mike Petersen <mike.petersen@ni.com>
+Date: Thu, 5 Jan 2023 09:16:08 -0600
+Subject: [PATCH] Don't print PID-uniquified core file for skipped test
+
+Signed-off-by: Mike Petersen <mike.petersen@ni.com>
+
+Upstream-Status: Inappropriate [other]
+This patch is NI specific. It removes the uniquified output to integrate
+better with our test systems, which recognize duplicate failures by
+comparing the error message to those seen previously.
+
+---
+ tests/backtrace-subr.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/backtrace-subr.sh b/tests/backtrace-subr.sh
+index b63e3814..fec10806 100644
+--- a/tests/backtrace-subr.sh
++++ b/tests/backtrace-subr.sh
+@@ -182,7 +182,7 @@ check_native_core()
+     fi
+   fi
+   if [ ! -f "$core" ]; then
+-    echo "No $core file generated";
++    echo "No core file generated";
+     exit 77;
+   fi
+ 
+-- 
+2.39.0
+


### PR DESCRIPTION
As noted in [AB#2232487](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2232487), the PID-uniquified file name here causes our test review system to think it's a new failure for each run.  
This change adds a patch to not print out that unique name.