### PR TITLE
[hardknott] opkg: ensure opkg uses private gpg.conf when applying keys.

### DIFF
--- a/meta/recipes-devtools/opkg/opkg/0002-opkg-key-remove-no-options-flag-from-gpg-calls.patch
+++ b/meta/recipes-devtools/opkg/opkg/0002-opkg-key-remove-no-options-flag-from-gpg-calls.patch
@@ -1,0 +1,34 @@
+From a658e6402382250f0164c5b47b744740e04f3611 Mon Sep 17 00:00:00 2001
+From: Charlie Johnston <charlie.johnston@ni.com>
+Date: Fri, 30 Dec 2022 15:21:14 -0600
+Subject: [PATCH] opkg-key: Remove --no-options flag from gpg calls.
+
+The opkg-key script was always passing the --no-options
+flag to gpg, which uses /dev/null as the options file.
+As a result, the opkg gpg.conf file was not getting
+used. This change removes that flag so that gpg.conf
+in the GPGHOMEDIR for opkg (currently /etc/opkg/gpg/)
+will be used if present.
+
+Upstream-Status: Accepted [https://git.yoctoproject.org/opkg/commit/?id=cee294e72d257417b5e55ef7a76a0fd15313e46b]
+Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>
+---
+ utils/opkg-key | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/utils/opkg-key b/utils/opkg-key
+index e395a59..8645ebc 100755
+--- a/utils/opkg-key
++++ b/utils/opkg-key
+@@ -53,7 +53,7 @@ else
+     exit 1
+ fi
+ 
+-GPG="$GPGCMD --no-options --homedir $GPGHOMEDIR"
++GPG="$GPGCMD --homedir $GPGHOMEDIR"
+ 
+ # Gpg home dir isn't created automatically when --homedir option is used
+ if [ ! -e "$GPGHOMEDIR" ]; then
+-- 
+2.30.2
+

--- a/meta/recipes-devtools/opkg/opkg_0.6.0.bb
+++ b/meta/recipes-devtools/opkg/opkg_0.6.0.bb
@@ -15,6 +15,7 @@ PE = "1"
 SRC_URI = "http://downloads.yoctoproject.org/releases/${BPN}/${BPN}-${PV}.tar.gz \
            file://opkg.conf \
            file://0001-opkg_conf-create-opkg.lock-in-run-instead-of-var-run.patch \
+           file://0002-opkg-key-remove-no-options-flag-from-gpg-calls.patch \
            file://run-ptest \
 "
 


### PR DESCRIPTION
Currently, the opkg-key utility calls gpg with --no-options, which uses /dev/null as the configuration file. This means any configurations in /etc/opkg/gpg/gpg.conf were being ignored. This change applies a patch to remove the --no-options flag.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>
Signed-off-by: Alexandre Belloni <alexandre.belloni@bootlin.com>
Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
(cherry picked from commit 3699096f3214e77fe4aa1daebe85308d02940f2f)

## Note to Reviewers:
I had to hand edit the cherry-pick to apply to `opkg_0.6.0.bb` instead of `opkg_0.6.1.bb`. This will not be cherry-picked into kirkstone at this time as we would instead want to cherry-pick the opkg upgrade with this fix at that time instead.

## Testing:
Built opkg locally. 