### PR TITLE
[kirkstone] create-spdx: Skip missing files when building from feeds.

### DIFF
--- a/meta/classes/create-spdx.bbclass
+++ b/meta/classes/create-spdx.bbclass
@@ -907,8 +907,15 @@ def combine_spdx(d, rootfs_name, rootfs_deploydir, rootfs_spdxid, packages):
     doc.packages.append(image)
 
     for name in sorted(packages.keys()):
-        pkg_spdx_path = deploy_dir_spdx / "packages" / (name + ".spdx.json")
-        pkg_doc, pkg_doc_sha1 = oe.sbom.read_doc(pkg_spdx_path)
+        try:
+            pkg_spdx_path = deploy_dir_spdx / "packages" / (name + ".spdx.json")
+            pkg_doc, pkg_doc_sha1 = oe.sbom.read_doc(pkg_spdx_path)
+        except FileNotFoundError:
+            if d.getVar('BUILD_IMAGES_FROM_FEEDS') == "1":
+                bb.warn("spdx: %s has no spdx available. Skipping." % name)
+                continue
+            else:
+                raise
 
         for p in pkg_doc.packages:
             if p.name == name:


### PR DESCRIPTION
Currently, the methods for creating spdx sboms will fail if an sbom for a package in the image is not found at the expected path (tmp/deploy/spdx/<arch>/packages/). In the case of building from feeds where the spdx files will not be found locally, this is undesireable.

This modifies the behavior to only warn if a file is missing when BUILD_IMAGES_FROM_FEEDS is enabled. This
is intended as a temporary solution until using other locations for spdx files can be supported

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

## Note to Reviewers:
I'm hoping this approach can be iterated on to be upstreamable. Right now, the logic only looks for spdx files locally. I'd like to get opinions on this and then we should probably consider adding logic to search for spdx.json files in a different location.

## Testing:
Built locally. Example warning messages:
```
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: libnitargetcfg has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-arch-gen has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-auth has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-auth-webservice has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-avahi-client has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-ca-certs has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-rt-exec-webservice has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-sdmon has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-service-locator has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-skyline-file-client has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-skyline-message-client has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-skyline-tag-client has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-software-action-services has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-software-installation-websvc has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-ssl-webserver-support has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-sysapi has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-sysapi-remote has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-sysapi-webservice has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-sysdetails-webservice has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-sysmgmt-auth-utils has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-sysmgmt-salt-minion-support has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-sysmgmt-sysapi-expert has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-system-webserver has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-traceengine has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-webdav-system-webserver-support has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-webserver-libs has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-webservices-webserver-support has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-wif-landingpage has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-wifibledd has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-wireless-ath6kl has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-wireless-cert-management-webservice has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: ni-wireless-cert-storage has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: nicurl has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: nirtcfg has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: nirtmdnsd has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: nissl has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: python3-ni-asset-discovery has no spdx available. Skipping.
WARNING: nilrt-runmode-rootfs-1.0-r0 do_rootfs: spdx: python3-ni-systemlink-sdk has no spdx available. Skipping.
NOTE: Tasks Summary: Attempted 11076 tasks of which 11057 didn't need to be rerun and all succeeded.

Summary: There were 90 WARNING messages.
```