### PR TITLE
[kirkstone] Create new packagefeed class to make feed builds easier

### DIFF
--- a/meta/classes/package_index.bbclass
+++ b/meta/classes/package_index.bbclass
@@ -1,0 +1,21 @@
+#
+#   Creates package indices for the IMAGE_PKGTYPE
+#
+
+do_package_index[nostamp] = "1"
+do_package_index[depends] += "${PACKAGEINDEXDEPS}"
+do_package_index[recrdeptask] += 'do_package_write_deb'
+do_package_index[recrdeptask] += 'do_package_write_ipk'
+do_package_index[recrdeptask] += 'do_package_write_rpm'
+
+python do_package_index() {
+    from oe.rootfs import generate_index_files
+    generate_index_files(d)
+}
+
+# Package indexes are required for the dummy SDK architectures
+# to support scenarios where SDK images are built from feeds.
+PACKAGE_ARCHS:append:task-package-index = " sdk-provides-dummy-target"
+SDK_PACKAGE_ARCHS:append:task-package-index = " sdk-provides-dummy-${SDKPKGSUFFIX}"
+
+addtask do_package_index before do_build

--- a/meta/classes/packagefeed.bbclass
+++ b/meta/classes/packagefeed.bbclass
@@ -1,0 +1,5 @@
+#
+#   Special case of packagegroup that includes package index builds.
+#
+
+inherit packagegroup package_index

--- a/meta/recipes-core/meta/package-index.bb
+++ b/meta/recipes-core/meta/package-index.bb
@@ -4,7 +4,7 @@ LICENSE = "MIT"
 INHIBIT_DEFAULT_DEPS = "1"
 PACKAGES = ""
 
-inherit nopackages
+inherit nopackages package_index
 
 deltask do_fetch
 deltask do_unpack
@@ -15,12 +15,4 @@ deltask do_install
 deltask do_populate_lic
 deltask do_populate_sysroot
 
-do_package_index[nostamp] = "1"
-do_package_index[depends] += "${PACKAGEINDEXDEPS}"
-
-python do_package_index() {
-    from oe.rootfs import generate_index_files
-    generate_index_files(d)
-}
-addtask do_package_index before do_build
 EXCLUDE_FROM_WORLD = "1"


### PR DESCRIPTION
Since we pretty much always need a package index built after feeds, it seems like having a method to designate a `packagegroup` as a `packagefeed` instead is useful. These two changes modify `package-index` to be a `package_index.bbclass` instead and adds a `packagefeed.bbclass`.

A separate PR will be posted modifying our `packagefeed-*` groups to inherit from this new structure.

## Note to reviewers:
I've limited this and no longer touch the SDK builds. The problem I ran into is that if a valid sstate cache existed for the packages, they would not be rebuilt before the image or SDK rootfs even if they weren't in the deploy directory. That makes sense to me since it's assumed those packages would likely be in a feed elsewhere for `BUILD_IMAGES_FROM_FEEDS` but unfortunately means there are cases where the build fails that I couldn't figure out a workaround for. This at least makes it so we no longer have to explicitly build the package indices when building our special feed groups. 

## Testing:
Built locally. 