### PR TITLE
Cherry-pick "github-releases: add a class that consolidates version checks"

### DIFF
--- a/meta/classes/github-releases.bbclass
+++ b/meta/classes/github-releases.bbclass
@@ -1,0 +1,3 @@
+GITHUB_BASE_URI ?= "https://github.com/${BPN}/${BPN}/releases/"
+UPSTREAM_CHECK_URI ?= "${GITHUB_BASE_URI}"
+UPSTREAM_CHECK_REGEX ?= "releases/tag/v?(?P<pver>\d+(\.\d+)+)"


### PR DESCRIPTION
github has recently changed how the releases page is structured: the tarballs are no longer listed directly, but are included via separate 'fragment' URIs. For now, we can change the check to match against the release tags.

This also establishes a common base URI to use for both fetching and checking the latest version.

Signed-off-by: Alexander Kanavin <alex@linutronix.de>
Signed-off-by: Alexandre Belloni <alexandre.belloni@bootlin.com>
Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
(cherry picked from commit afa57a02ecd12ad176302d9631f4181b26d94f5c)
[gratian: adjust path from 'meta/classes-recipe' to 'meta/classes' to match kirkstone layout]
Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>

### Note to maintainers

- This cherry-pick is needed for `meta-openembedded` PR https://github.com/ni/meta-openembedded/pull/37. Please merge first.

### Testing

- bitbake nilrt-base-system-image
- bitbake nilrt-safemode-rootfs