### PR TITLE
libxpm: upgrade 3.5.15 -> 3.5.16

### DIFF
--- a/meta/recipes-graphics/xorg-lib/libxpm_3.5.16.bb
+++ b/meta/recipes-graphics/xorg-lib/libxpm_3.5.16.bb
@@ -23,7 +23,6 @@ PACKAGES =+ "sxpm cxpm"
 FILES:cxpm = "${bindir}/cxpm"
 FILES:sxpm = "${bindir}/sxpm"
 
-SRC_URI[md5sum] = "b3c58c94e284fd6940d3615e660a0007"
-SRC_URI[sha256sum] = "60bb906c5c317a6db863e39b69c4a83fdbd2ae2154fcf47640f8fefc9fdfd1c1"
+SRC_URI[sha256sum] = "e6bc5da7a69dbd9bcc67e87c93d4904fe2f5177a0711c56e71fa2f6eff649f51"
 
 BBCLASSEXTEND = "native"


### PR DESCRIPTION
Cherry pick commit 4d9f0958eecdf683434d77a4f65611803cffd247 ("libxpm: upgrade 3.5.15 -> 3.5.16") from upstream master to address CVEs: CVE-2022-4883, CVE-2022-44617, CVE-2022-46285.

AD [#2408710](https://dev.azure.com/ni/DevCentral/_workitems/edit/2408710)

### Testing

- added `INHERIT += "cve-check"` to local.conf
- `bitbake libxpm`
- `bitbake nilrt-base-system-image`
- verified the `cve-summary` log shows libxpm CVEs are patched:

```
LAYER: meta                                                                                                                                                                                   
PACKAGE NAME: libxpm                                                                                                                                                                          
PACKAGE VERSION: 1_3.5.16                                                                                                                                                                     
CVE: CVE-2016-10164                                                                                                                                                                           
CVE STATUS: Patched                                                                                                                                                                           
CVE SUMMARY: Multiple integer overflows in libXpm before 3.5.12, when a program requests parsing XPM extensions on a 64-bit platform, allow remote attackers to cause a denial of service (ou\
t-of-bounds write) or execute arbitrary code via (1) the number of extensions or (2) their concatenated length in a crafted XPM file, which triggers a heap-based buffer overflow.            
CVSS v2 BASE SCORE: 7.5                                                                                                                                                                       
CVSS v3 BASE SCORE: 9.8                                                                                                                                                                       
VECTOR: NETWORK                                                                                                                                                                               
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2016-10164                                                                                                                             
                                                                                                                                                                                              
LAYER: meta                                                                                                                                                                                   
PACKAGE NAME: libxpm                                                                                                                                                                          
PACKAGE VERSION: 1_3.5.16                                                                                                                                                                     
CVE: CVE-2022-44617                                                                                                                                                                           
CVE STATUS: Patched                                                                                                                                                                           
CVE SUMMARY: A flaw was found in libXpm. When processing a file with width of 0 and a very large height, some parser functions will be called repeatedly and can lead to an infinite loop, re\
sulting in a Denial of Service in the application linked to the library.                                                                                                                      
CVSS v2 BASE SCORE: 0.0                                                                                                                                                                       
CVSS v3 BASE SCORE: 7.5                                                                                                                                                                       
VECTOR: NETWORK                                                                                                                                                                               
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2022-44617                                                                                                                             
                                                                                                                                                                                              
LAYER: meta                                                                                                                                                                                   
PACKAGE NAME: libxpm                                                                                                                                                                          
PACKAGE VERSION: 1_3.5.16                                                                                                                                                                     
CVE: CVE-2022-46285                                                                                                                                                                           
CVE STATUS: Patched                                                                                                                                                                           
CVE SUMMARY: A flaw was found in libXpm. This issue occurs when parsing a file with a comment not closed; the end-of-file condition will not be detected, leading to an infinite loop and res\
ulting in a Denial of Service in the application linked to the library.                                                                                                                       
CVSS v2 BASE SCORE: 0.0                                                                                                                                                                       
CVSS v3 BASE SCORE: 7.5                                                                                                                                                                       
VECTOR: NETWORK                                                                                                                                                                               
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2022-46285                                                                                                                             
                                                                                                                                                                                              
LAYER: meta                                                                                                                                                                                   
PACKAGE NAME: libxpm                                                                                                                                                                          
PACKAGE VERSION: 1_3.5.16                                                                                                                                                                     
CVE: CVE-2022-4883                                                                                                                                                                            
CVE STATUS: Patched                                                                                                                                                                           
CVE SUMMARY: A flaw was found in libXpm. When processing files with .Z or .gz extensions, the library calls external programs to compress and uncompress files, relying on the PATH environme\
nt variable to find these programs, which could allow a malicious user to execute other programs by manipulating the PATH environment variable.                                               
CVSS v2 BASE SCORE: 0.0                                                                                                                                                                       
CVSS v3 BASE SCORE: 8.8                                                                                                                                                                       
VECTOR: NETWORK                                                                                                                                                                               
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2022-4883
```