### PR TITLE
ncurses: upgrade 6.3+20220423 -> 6.4

### DIFF
--- a/meta/recipes-core/ncurses/files/exit_prototype.patch
+++ b/meta/recipes-core/ncurses/files/exit_prototype.patch
@@ -1,0 +1,22 @@
+Add needed headers for including mbstate_t and exit()
+
+Upstream-Status: Inappropriate [Reconfigure will solve it]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+--- a/configure
++++ b/configure
+@@ -3422,6 +3422,7 @@ rm -f "conftest.$ac_objext" "conftest.$a
+   cat >"conftest.$ac_ext" <<_ACEOF
+ #line 3423 "configure"
+ #include "confdefs.h"
++#include <stdlib.h>
+ $ac_declaration
+ int
+ main (void)
+@@ -12997,6 +12998,7 @@ cat >"conftest.$ac_ext" <<_ACEOF
+ #include <stdlib.h>
+ #include <stdarg.h>
+ #include <stdio.h>
++#include <wchar.h>
+ #ifdef HAVE_LIBUTF8_H
+ #include <libutf8.h>
+ #endif

--- a/meta/recipes-core/ncurses/files/exit_prototype.patch
+++ b/meta/recipes-core/ncurses/files/exit_prototype.patch
@@ -1,18 +1,28 @@
-Add needed headers for including mbstate_t and exit()
+From 4a769a441d7e57a23017c3037cde3e53fb9f35fe Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 30 Aug 2022 15:58:32 -0700
+Subject: [PATCH] Add needed headers for including mbstate_t and exit()
 
 Upstream-Status: Inappropriate [Reconfigure will solve it]
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+---
+ configure | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configure b/configure
+index f377f551..163f8899 100755
 --- a/configure
 +++ b/configure
-@@ -3422,6 +3422,7 @@ rm -f "conftest.$ac_objext" "conftest.$a
+@@ -3423,6 +3423,7 @@ rm -f "conftest.$ac_objext" "conftest.$ac_ext"
    cat >"conftest.$ac_ext" <<_ACEOF
- #line 3423 "configure"
+ #line 3424 "configure"
  #include "confdefs.h"
 +#include <stdlib.h>
  $ac_declaration
  int
  main (void)
-@@ -12997,6 +12998,7 @@ cat >"conftest.$ac_ext" <<_ACEOF
+@@ -13111,6 +13112,7 @@ cat >"conftest.$ac_ext" <<_ACEOF
  #include <stdlib.h>
  #include <stdarg.h>
  #include <stdio.h>

--- a/meta/recipes-core/ncurses/ncurses.inc
+++ b/meta/recipes-core/ncurses/ncurses.inc
@@ -13,7 +13,7 @@ BINCONFIG = "${bindir}/ncurses5-config ${bindir}/ncursesw5-config \
 inherit autotools binconfig-disabled multilib_header pkgconfig
 
 # Upstream has useful patches at times at ftp://invisible-island.net/ncurses/
-SRC_URI = "git://salsa.debian.org/debian/ncurses.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/mirror/ncurses.git;protocol=https;branch=master"
 
 EXTRA_AUTORECONF = "-I m4"
 

--- a/meta/recipes-core/ncurses/ncurses_6.3+20220423.bb
+++ b/meta/recipes-core/ncurses/ncurses_6.3+20220423.bb
@@ -3,6 +3,7 @@ require ncurses.inc
 SRC_URI += "file://0001-tic-hang.patch \
            file://0002-configure-reproducible.patch \
            file://0003-gen-pkgconfig.in-Do-not-include-LDFLAGS-in-generated.patch \
+           file://exit_prototype.patch \
            "
 # commit id corresponds to the revision in package version
 SRCREV = "20db1fb41ec91cd8a1f528e770362092c5403378"

--- a/meta/recipes-core/ncurses/ncurses_6.3+20220423.bb
+++ b/meta/recipes-core/ncurses/ncurses_6.3+20220423.bb
@@ -5,7 +5,7 @@ SRC_URI += "file://0001-tic-hang.patch \
            file://0003-gen-pkgconfig.in-Do-not-include-LDFLAGS-in-generated.patch \
            "
 # commit id corresponds to the revision in package version
-SRCREV = "a0bc708bc6954b5d3c0a38d92b683c3ec3135260"
+SRCREV = "20db1fb41ec91cd8a1f528e770362092c5403378"
 S = "${WORKDIR}/git"
 EXTRA_OECONF += "--with-abi-version=5"
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d+(\.\d+)+)$"

--- a/meta/recipes-core/ncurses/ncurses_6.4.bb
+++ b/meta/recipes-core/ncurses/ncurses_6.4.bb
@@ -6,10 +6,10 @@ SRC_URI += "file://0001-tic-hang.patch \
            file://exit_prototype.patch \
            "
 # commit id corresponds to the revision in package version
-SRCREV = "20db1fb41ec91cd8a1f528e770362092c5403378"
+SRCREV = "79b9071f2be20a24c7be031655a5638f6032f29f"
 S = "${WORKDIR}/git"
 EXTRA_OECONF += "--with-abi-version=5"
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d+(\.\d+)+)$"
 
 # This is needed when using patchlevel versions like 6.1+20181013
-CVE_VERSION = "${@d.getVar("PV").split('+')[0]}.${@d.getVar("PV").split('+')[1]}"
+#CVE_VERSION = "${@d.getVar("PV").split('+')[0]}.${@d.getVar("PV").split('+')[1]}"


### PR DESCRIPTION
Cherry pick upstream master commits needed to upgrade ncurses from 6.3+20220423 to 6.4 in order to address [CVE-2023-29491](https://nvd.nist.gov/vuln/detail/CVE-2023-29491).

AD [#2408712](https://dev.azure.com/ni/DevCentral/_workitems/edit/2408712)

### Testing

- added INHERIT += "cve-check" to local.conf, called `bitbake ncurses` and verified the 'cve-summary' log shows the CVE listed above as patched:
```
LAYER: meta                                                                                                                                                                                   
PACKAGE NAME: ncurses                                                                                                                                                                         
PACKAGE VERSION: 6.4                                                                                                                                                                          
CVE: CVE-2023-29491                                                                                                                                                                           
CVE STATUS: Patched                                                                                                                                                                           
CVE SUMMARY: ncurses before 6.4 20230408, when used by a setuid application, allows local users to trigger security-relevant memory corruption via malformed data in a terminfo database file\
 that is found in $HOME/.terminfo or reached via the TERMINFO or TERM environment variable.                                                                                                   
CVSS v2 BASE SCORE: 0.0                                                                                                                                                                       
CVSS v3 BASE SCORE: 7.8                                                                                                                                                                       
VECTOR: LOCAL                                                                                                                                                                                 
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2023-29491  
```
- also tested `bitbake nilrt-base-system-image` and `bitbake nilrt-safemode-rootfs`