### PR TITLE
cve-update-nvd2-native: Handle 503 responses

### DIFF
--- a/meta/recipes-core/meta/cve-update-nvd2-native.bb
+++ b/meta/recipes-core/meta/cve-update-nvd2-native.bb
@@ -115,6 +115,7 @@ def nvd_request_next(url, api_key, args):
     Request next part of the NVD dabase
     """
 
+    import urllib.error
     import urllib.request
     import urllib.parse
     import gzip
@@ -127,6 +128,10 @@ def nvd_request_next(url, api_key, args):
     data = urllib.parse.urlencode(args)
 
     full_request = url + '?' + data
+
+    codes_to_retry = {
+        503, # Service Unavailable
+    }
 
     for attempt in range(3):
         try:
@@ -147,6 +152,13 @@ def nvd_request_next(url, api_key, args):
         except http.client.IncompleteRead:
             # Read incomplete, let's try again
             bb.debug(2, "CVE database: received incomplete data, retrying (request: %s)" %(full_request))
+            pass
+        except urllib.error.HTTPError as e:
+            if e.code not in codes_to_retry:
+                raise
+            bb.debug(2, "CVE database: received response code %d, retrying (request: %s)" %(e.code, full_request))
+            # Wait for the same duration as between pages
+            time.sleep(6)
             pass
         else:
             return raw_data


### PR DESCRIPTION
This recipe was recently observed to fail due to intermittent responses of 503 Service Unavailable. As these error responses were intermittent (presumably due to a load balancer or similar mechanism), waiting and reattempting the request is a reasonable way to handle it.

Here is a snippet of debug output from the log of the do_fetch step (with extra output not in this PR):

```
DEBUG: Request: https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=132000
DEBUG: Attempt: 1
DEBUG: CVE database: received response code 503, retrying (request: https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=132000)
DEBUG: Attempt: 2
DEBUG: Attempt 2 successful
DEBUG: Request: https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=134000
DEBUG: Attempt: 1
DEBUG: Attempt 1 successful
DEBUG: Request: https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=136000
DEBUG: Attempt: 1
DEBUG: Attempt 1 successful
DEBUG: Request: https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=138000
DEBUG: Attempt: 1
DEBUG: Attempt 1 successful
DEBUG: Request: https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=140000
DEBUG: Attempt: 1
DEBUG: Attempt 1 successful
DEBUG: Request: https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=142000
DEBUG: Attempt: 1
DEBUG: CVE database: received response code 503, retrying (request: https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=142000)
DEBUG: Attempt: 2
DEBUG: Attempt 2 successful
```

[AB#2447323](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2447323)