### PR TITLE
cve-update-nvd2-native: Add other status codes to retry

### DIFF
--- a/meta/recipes-core/meta/cve-update-nvd2-native.bb
+++ b/meta/recipes-core/meta/cve-update-nvd2-native.bb
@@ -130,7 +130,7 @@ def nvd_request_next(url, api_key, args):
     full_request = url + '?' + data
 
     codes_to_retry = {
-        503, # Service Unavailable
+        http.HTTPStatus.SERVICE_UNAVAILABLE.value,
     }
 
     for attempt in range(3):

--- a/meta/recipes-core/meta/cve-update-nvd2-native.bb
+++ b/meta/recipes-core/meta/cve-update-nvd2-native.bb
@@ -130,7 +130,10 @@ def nvd_request_next(url, api_key, args):
     full_request = url + '?' + data
 
     codes_to_retry = {
+        http.HTTPStatus.TOO_MANY_REQUESTS.value,
+        http.HTTPStatus.BAD_GATEWAY.value,
         http.HTTPStatus.SERVICE_UNAVAILABLE.value,
+        http.HTTPStatus.GATEWAY_TIMEOUT.value,
     }
 
     for attempt in range(3):


### PR DESCRIPTION
As mentioned in comments on #105, other status codes are likely to benefit from retrying, such as those listed [here][1].

This change also switches to using the constants from the [`http.HTTPStatus` enum][2].

[1]: <https://cloud.google.com/workflows/docs/reference/syntax/retrying#retry-idempotent>
[2]: <https://docs.python.org/3/library/http.html#http.HTTPStatus>

[AB#2447323](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2447323)