### PR TITLE
[kirkstone] libpcre2: patch CVE-2022-41409

### DIFF
--- a/meta/recipes-support/libpcre/libpcre2/CVE-2022-41409.patch
+++ b/meta/recipes-support/libpcre/libpcre2/CVE-2022-41409.patch
@@ -1,0 +1,75 @@
+From 94e1c001761373b7d9450768aa15d04c25547a35 Mon Sep 17 00:00:00 2001
+From: Philip Hazel <Philip.Hazel@gmail.com>
+Date: Tue, 16 Aug 2022 17:00:45 +0100
+Subject: [PATCH] Diagnose negative repeat value in pcre2test subject line
+
+CVE: CVE-2022-41409
+Upstream-Status: Backport [https://github.com/PCRE2Project/pcre2/commit/94e1c001761373b7d9450768aa15d04c25547a35]
+
+Signed-off-by: Peter Marko <peter.marko@siemens.com>
+
+---
+ ChangeLog            | 3 +++
+ src/pcre2test.c      | 4 ++--
+ testdata/testinput2  | 3 +++
+ testdata/testoutput2 | 4 ++++
+ 4 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index eab50eb7..276eb57a 100644
+--- a/ChangeLog
++++ b/ChangeLog
+index eab50eb7..276eb57a 100644
+@@ -1,6 +1,9 @@
+ Change Log for PCRE2
+ --------------------
+ 
++20. A negative repeat value in a pcre2test subject line was not being 
++diagnosed, leading to infinite looping.
++
+ 
+ Version 10.40 15-April-2022
+ ---------------------------
+diff --git a/src/pcre2test.c b/src/pcre2test.c
+index 08f86096..f6f5d66c 100644
+--- a/src/pcre2test.c
++++ b/src/pcre2test.c
+@@ -6781,9 +6781,9 @@ while ((c = *p++) != 0)
+       }
+ 
+     i = (int32_t)li;
+-    if (i-- == 0)
++    if (i-- <= 0)
+       {
+-      fprintf(outfile, "** Zero repeat not allowed\n");
++      fprintf(outfile, "** Zero or negative repeat not allowed\n");
+       return PR_OK;
+       }
+ 
+diff --git a/testdata/testinput2 b/testdata/testinput2
+index d37d8f30..717ba2ae 100644
+--- a/testdata/testinput2
++++ b/testdata/testinput2
+@@ -5932,4 +5932,7 @@ a)"xI
+ /[Aa]{2,3}/BI
+     aabcd
+ 
++--
++    \[X]{-10}
++
+ # End of testinput2
+diff --git a/testdata/testoutput2 b/testdata/testoutput2
+index ce090f8c..d2188d3c 100644
+--- a/testdata/testoutput2
++++ b/testdata/testoutput2
+@@ -17746,6 +17746,10 @@ Subject length lower bound = 2
+     aabcd
+  0: aa
+ 
++--
++    \[X]{-10}
++** Zero or negative repeat not allowed
++
+ # End of testinput2
+ Error -70: PCRE2_ERROR_BADDATA (unknown error number)
+ Error -62: bad serialized data

--- a/meta/recipes-support/libpcre/libpcre2_10.40.bb
+++ b/meta/recipes-support/libpcre/libpcre2_10.40.bb
@@ -11,6 +11,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENCE;md5=41bfb977e4933c506588724ce69bf5d2"
 
 SRC_URI = "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-${PV}/pcre2-${PV}.tar.bz2 \
+    file://CVE-2022-41409.patch \
 "
 UPSTREAM_CHECK_URI = "https://github.com/PhilipHazel/pcre2/releases"
 


### PR DESCRIPTION
Cherry-pick a fix for CVE-2022-41409 which has already been merged in the upstream OE-core `kirkstone` stable branch for several weeks.

```
Backport commit mentioned in NVD DB links.
https://github.com/PCRE2Project/pcre2/commit/94e1c001761373b7d9450768aa15d04c25547a35

Signed-off-by: Peter Marko <peter.marko@siemens.com>
Signed-off-by: Steve Sakoman <steve@sakoman.com>
(cherry picked from commit 410cdbc70cfba709ec5bef508e772f52514ba28a)
```

NI AZDO ID: https://dev.azure.com/ni/DevCentral/_workitems/edit/2517362

# Testing
* [x] Built `libpcre2` locally and confirmed that the recipe still works.