### PR TITLE
parted: add delay in ptests to avoid dmesg error

### DIFF
--- a/meta/recipes-extended/parted/files/0001-tests-add-delay-in-ptests-to-avoid-dmesg-error.patch
+++ b/meta/recipes-extended/parted/files/0001-tests-add-delay-in-ptests-to-avoid-dmesg-error.patch
@@ -1,0 +1,55 @@
+From 41ebb6af13d3d3e45d6037398260c9264ecc297b Mon Sep 17 00:00:00 2001
+From: Dylan Turner <dylan.turner@ni.com>
+Upstream-Status: Inappropriate other
+Date: Tue, 26 Sep 2023 01:47:34 -0500
+Subject: [PATCH] tests: add delay in ptests to avoid dmesg error
+
+Signed-off-by: Dylan Turner <dylan.turner@ni.com>
+---
+ tests/t1104-remove-and-add-partition.sh | 3 +++
+ tests/t8000-loop.sh                     | 2 ++
+ 2 files changed, 5 insertions(+)
+
+diff --git a/tests/t1104-remove-and-add-partition.sh b/tests/t1104-remove-and-add-partition.sh
+index 657b180..c6cb6c3 100644
+--- a/tests/t1104-remove-and-add-partition.sh
++++ b/tests/t1104-remove-and-add-partition.sh
+@@ -36,15 +36,18 @@ require_partitionable_loop_device_ $d1
+ 
+ # create one big partition
+ parted -s $d1 mklabel msdos mkpart primary ext2 1m 10m || fail=1
++sleep 0.5
+ 
+ # save this table
+ dd if=$d1 of=saved count=1 || fail=1
+ 
+ # create two small partitions
+ parted -s $d1 mklabel msdos mkpart primary ext2 1m 5m mkpart primary ext2 5m 10m || fail=1
++sleep 0.5
+ 
+ # restore first table and make sure partprobe works
+ dd if=saved of=$d1 || fail=1
+ partprobe $d1 || fail=1
++sleep 0.5
+ 
+ Exit $fail
+diff --git a/tests/t8000-loop.sh b/tests/t8000-loop.sh
+index 793e279..7f37d36 100755
+--- a/tests/t8000-loop.sh
++++ b/tests/t8000-loop.sh
+@@ -35,10 +35,12 @@ require_partitionable_loop_device_ $d1
+ 
+ # Expect this to succeed.
+ parted -s $d1 mklabel msdos > err 2>&1 || fail=1
++sleep 0.5
+ compare /dev/null err || fail=1     # expect no output
+ 
+ # Create a partition
+ parted -s $d1 mkpart primary 1 10 > err 2>&1 || fail=1
++sleep 0.5
+ compare /dev/null err || fail=1     # expect no output
+ 
+ Exit $fail
+-- 
+2.40.1
+

--- a/meta/recipes-extended/parted/parted_3.4.bb
+++ b/meta/recipes-extended/parted/parted_3.4.bb
@@ -8,6 +8,7 @@ DEPENDS = "ncurses util-linux virtual/libiconv"
 
 SRC_URI = "${GNU_MIRROR}/parted/parted-${PV}.tar.xz \
            file://fix-doc-mandir.patch \
+           file://0001-tests-add-delay-in-ptests-to-avoid-dmesg-error.patch \
            file://run-ptest \
            file://check-vfat.patch \
            "


### PR DESCRIPTION
## Reason

Internal bug [2507380](https://dev.azure.com/ni/DevCentral/_workitems/edit/2507380/)

We have ptests throwing dmesg errors due to a race condition between our udev code and the parted test. Essentially, when parted is called on a loop device too quickly before doing file operations on said loop device, the operation may work, but it will show an error in dmesg, which affects our testing.

Since there is really no effect other than this specific test throwing an error and digging into our udev code is quite an undertaking (and bc it doesn't affect upstream), actually fixing this minor issue is pretty low ROI.

Thus, the best course of action is simply to add a delay after parted commands. There are two ptests affected, t1104 and t8000.

## Testing

Built parted with `bitbake parted`, installed the new `parted-ptest` package, and verified there was no longer dmesg error output from the tests that previously generated some.