### PR TITLE
[RFC] Patch binutils CVEs

### DIFF
--- a/meta/recipes-devtools/binutils/binutils-2.38.inc
+++ b/meta/recipes-devtools/binutils/binutils-2.38.inc
@@ -58,5 +58,7 @@ SRC_URI = "\
      file://0025-CVE-2023-25588.patch \
      file://0027-CVE-2022-44840.patch \
      file://0028-CVE-2022-47695.patch \
+     file://0029-CVE-2022-45703-1.patch \
+     file://0029-CVE-2022-45703-2.patch \
 "
 S  = "${WORKDIR}/git"

--- a/meta/recipes-devtools/binutils/binutils-2.38.inc
+++ b/meta/recipes-devtools/binutils/binutils-2.38.inc
@@ -57,5 +57,6 @@ SRC_URI = "\
      file://0026-CVE-2023-1972.patch \
      file://0025-CVE-2023-25588.patch \
      file://0027-CVE-2022-44840.patch \
+     file://0028-CVE-2022-47695.patch \
 "
 S  = "${WORKDIR}/git"

--- a/meta/recipes-devtools/binutils/binutils-2.38.inc
+++ b/meta/recipes-devtools/binutils/binutils-2.38.inc
@@ -56,5 +56,6 @@ SRC_URI = "\
      file://0023-CVE-2023-25585.patch \
      file://0026-CVE-2023-1972.patch \
      file://0025-CVE-2023-25588.patch \
+     file://0027-CVE-2022-44840.patch \
 "
 S  = "${WORKDIR}/git"

--- a/meta/recipes-devtools/binutils/binutils/0022-CVE-2023-25584-3.patch
+++ b/meta/recipes-devtools/binutils/binutils/0022-CVE-2023-25584-3.patch
@@ -35,8 +35,10 @@ Lack of bounds checking in vms-alpha.c parse_module
 Upstream-Status: Backport [https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff_plain;h=77c225bdeb410cf60da804879ad41622f5f1aa44]
 
 CVE: CVE-2023-25584
+CVE: CVE-2022-47673
 
 Signed-off-by: Deepthi Hemraj <Deepthi.Hemraj@windriver.com>
+Signed-off-by: Chaitanya Vadrevu <chaitanya.vadrevu@ni.com>
 
 ---
 

--- a/meta/recipes-devtools/binutils/binutils/0025-CVE-2023-25588.patch
+++ b/meta/recipes-devtools/binutils/binutils/0025-CVE-2023-25588.patch
@@ -17,8 +17,10 @@ anyway, so get rid of them.  Also, simplify and correct sanity checks.
 Upstream-Status: Backport [https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff_plain;h=d12f8998d2d086f0a6606589e5aedb7147e6f2f1]
 
 CVE: CVE-2023-25588
+CVE: CVE-2022-47696
 
 Signed-off-by: Deepthi Hemraj <Deepthi.Hemraj@windriver.com>
+Signed-off-by: Chaitanya Vadrevu <chaitanya.vadrevu@ni.com>
 
 ---
 

--- a/meta/recipes-devtools/binutils/binutils/0027-CVE-2022-44840.patch
+++ b/meta/recipes-devtools/binutils/binutils/0027-CVE-2022-44840.patch
@@ -1,0 +1,134 @@
+From 82e129adcbc5c7e16e3856fd170e9a46b93a8acb Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Sun, 30 Oct 2022 19:08:51 +1030
+Subject: [PATCH] Pool section entries for DWP version 1
+
+Ref: https://gcc.gnu.org/wiki/DebugFissionDWP?action=recall&rev=3
+
+Fuzzers have found a weakness in the code stashing pool section
+entries.  With random nonsensical values in the index entries (rather
+than each index pointing to its own set distinct from other sets),
+it's possible to overflow the space allocated, losing the NULL
+terminator.  Without a terminator, find_section_in_set can run off the
+end of the shndx_pool buffer.  Fix this by scanning the pool directly.
+
+binutils/
+	* dwarf.c (add_shndx_to_cu_tu_entry): Delete range check.
+	(end_cu_tu_entry): Likewise.
+	(process_cu_tu_index): Fill shndx_pool by directly scanning
+	pool, rather than indirectly from index entries.
+
+Upstream-Status: Backport [https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=28750e3b967da2207d51cbce9fc8be262817ee59]
+
+CVE: CVE-2022-44840
+
+Signed-off-by: Chaitanya Vadrevu <chaitanya.vadrevu@ni.com>
+---
+ binutils/dwarf.c | 68 +++++++++++++++++++++---------------------------
+ 1 file changed, 30 insertions(+), 38 deletions(-)
+
+diff --git a/binutils/dwarf.c b/binutils/dwarf.c
+index f8fa2f68387..2d151c60817 100644
+--- a/binutils/dwarf.c
++++ b/binutils/dwarf.c
+@@ -10705,22 +10705,12 @@ prealloc_cu_tu_list (unsigned int nshndx)
+ static void
+ add_shndx_to_cu_tu_entry (unsigned int shndx)
+ {
+-  if (shndx_pool_used >= shndx_pool_size)
+-    {
+-      error (_("Internal error: out of space in the shndx pool.\n"));
+-      return;
+-    }
+   shndx_pool [shndx_pool_used++] = shndx;
+ }
+ 
+ static void
+ end_cu_tu_entry (void)
+ {
+-  if (shndx_pool_used >= shndx_pool_size)
+-    {
+-      error (_("Internal error: out of space in the shndx pool.\n"));
+-      return;
+-    }
+   shndx_pool [shndx_pool_used++] = 0;
+ }
+ 
+@@ -10826,26 +10816,34 @@ process_cu_tu_index (struct dwarf_section *section, int do_display)
+ 
+   if (version == 1)
+     {
++      unsigned char *shndx_list;
++      unsigned int shndx;
++
+       if (!do_display)
+-	prealloc_cu_tu_list ((limit - ppool) / 4);
+-      for (i = 0; i < nslots; i++)
+ 	{
+-	  unsigned char *shndx_list;
+-	  unsigned int shndx;
+-
+-	  SAFE_BYTE_GET (signature, phash, 8, limit);
+-	  if (signature != 0)
++	  prealloc_cu_tu_list ((limit - ppool) / 4);
++	  for (shndx_list = ppool + 4; shndx_list <= limit - 4; shndx_list += 4)
+ 	    {
+-	      SAFE_BYTE_GET (j, pindex, 4, limit);
+-	      shndx_list = ppool + j * 4;
+-	      /* PR 17531: file: 705e010d.  */
+-	      if (shndx_list < ppool)
+-		{
+-		  warn (_("Section index pool located before start of section\n"));
+-		  return 0;
+-		}
++	      shndx = byte_get (shndx_list, 4);
++	      add_shndx_to_cu_tu_entry (shndx);
++	    }
++	  end_cu_tu_entry ();
++	}
++      else
++	for (i = 0; i < nslots; i++)
++	  {
++	    SAFE_BYTE_GET (signature, phash, 8, limit);
++	    if (signature != 0)
++	      {
++		SAFE_BYTE_GET (j, pindex, 4, limit);
++		shndx_list = ppool + j * 4;
++		/* PR 17531: file: 705e010d.  */
++		if (shndx_list < ppool)
++		  {
++		    warn (_("Section index pool located before start of section\n"));
++		    return 0;
++		  }
+ 
+-	      if (do_display)
+ 		printf (_("  [%3d] Signature:  0x%s  Sections: "),
+ 			i, dwarf_vmatoa ("x", signature));
+ 	      for (;;)
+@@ -10859,20 +10857,14 @@ process_cu_tu_index (struct dwarf_section *section, int do_display)
+ 		  SAFE_BYTE_GET (shndx, shndx_list, 4, limit);
+ 		  if (shndx == 0)
+ 		    break;
+-		  if (do_display)
+ 		    printf (" %d", shndx);
+-		  else
+-		    add_shndx_to_cu_tu_entry (shndx);
+-		  shndx_list += 4;
+-		}
+-	      if (do_display)
++		    shndx_list += 4;
++		  }
+ 		printf ("\n");
+-	      else
+-		end_cu_tu_entry ();
+-	    }
+-	  phash += 8;
+-	  pindex += 4;
+-	}
++	      }
++	    phash += 8;
++	    pindex += 4;
++	  }
+     }
+   else if (version == 2)
+     {

--- a/meta/recipes-devtools/binutils/binutils/0028-CVE-2022-47695.patch
+++ b/meta/recipes-devtools/binutils/binutils/0028-CVE-2022-47695.patch
@@ -1,0 +1,58 @@
+From 2f7426b9bb2d2450b32cad3d79fab9abe3ec42bb Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Sun, 4 Dec 2022 22:15:40 +1030
+Subject: [PATCH] PR29846, segmentation fault in objdump.c compare_symbols
+
+Fixes a fuzzed object file problem where plt relocs were manipulated
+in such a way that two synthetic symbols were generated at the same
+plt location.  Won't occur in real object files.
+
+	PR 29846
+	PR 20337
+	* objdump.c (compare_symbols): Test symbol flags to exclude
+	section and synthetic symbols before attempting to check flavour.
+
+Upstream-Status: Backport [https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=3d3af4ba39e892b1c544d667ca241846bc3df386]
+
+CVE: CVE-2022-47695
+
+Signed-off-by: Chaitanya Vadrevu <chaitanya.vadrevu@ni.com>
+---
+ binutils/objdump.c | 23 ++++++++++-------------
+ 1 file changed, 10 insertions(+), 13 deletions(-)
+
+diff --git a/binutils/objdump.c b/binutils/objdump.c
+index 08a0fe521d8..21f75f4db40 100644
+--- a/binutils/objdump.c
++++ b/binutils/objdump.c
+@@ -1165,20 +1165,17 @@ compare_symbols (const void *ap, const void *bp)
+ 	return 1;
+     }
+ 
+-  if (bfd_get_flavour (bfd_asymbol_bfd (a)) == bfd_target_elf_flavour
++  /* Sort larger size ELF symbols before smaller.  See PR20337.  */
++  bfd_vma asz = 0;
++  if ((a->flags & (BSF_SECTION_SYM | BSF_SYNTHETIC)) == 0
++      && bfd_get_flavour (bfd_asymbol_bfd (a)) == bfd_target_elf_flavour)
++    asz = ((elf_symbol_type *) a)->internal_elf_sym.st_size;
++  bfd_vma bsz = 0;
++  if ((b->flags & (BSF_SECTION_SYM | BSF_SYNTHETIC)) == 0
+       && bfd_get_flavour (bfd_asymbol_bfd (b)) == bfd_target_elf_flavour)
+-    {
+-      bfd_vma asz, bsz;
+-
+-      asz = 0;
+-      if ((a->flags & (BSF_SECTION_SYM | BSF_SYNTHETIC)) == 0)
+-	asz = ((elf_symbol_type *) a)->internal_elf_sym.st_size;
+-      bsz = 0;
+-      if ((b->flags & (BSF_SECTION_SYM | BSF_SYNTHETIC)) == 0)
+-	bsz = ((elf_symbol_type *) b)->internal_elf_sym.st_size;
+-      if (asz != bsz)
+-	return asz > bsz ? -1 : 1;
+-    }
++    bsz = ((elf_symbol_type *) b)->internal_elf_sym.st_size;
++  if (asz != bsz)
++    return asz > bsz ? -1 : 1;
+ 
+   /* Symbols that start with '.' might be section names, so sort them
+      after symbols that don't start with '.'.  */

--- a/meta/recipes-devtools/binutils/binutils/0029-CVE-2022-45703-1.patch
+++ b/meta/recipes-devtools/binutils/binutils/0029-CVE-2022-45703-1.patch
@@ -1,0 +1,146 @@
+From 02c8847ad5686f77a842cdb395a41240445f90de Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Tue, 24 May 2022 09:32:14 +0930
+Subject: [PATCH] PR29169, invalid read displaying fuzzed .gdb_index
+
+	PR 29169
+	* dwarf.c (display_gdb_index): Combine sanity checks.  Calculate
+	element counts, not word counts.
+
+Upstream-Status: Backport [https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=244e19c79111eed017ee38ab1d44fb2a6cd1b636]
+
+CVE: CVE-2022-45703
+
+Signed-off-by: Chaitanya Vadrevu <chaitanya.vadrevu@ni.com>
+---
+ binutils/dwarf.c | 80 +++++++++++++-----------------------------------
+ 1 file changed, 22 insertions(+), 58 deletions(-)
+
+diff --git a/binutils/dwarf.c b/binutils/dwarf.c
+index 2d151c60817..5e802ac78cd 100644
+--- a/binutils/dwarf.c
++++ b/binutils/dwarf.c
+@@ -10463,7 +10463,7 @@ display_gdb_index (struct dwarf_section *section,
+   uint32_t cu_list_offset, tu_list_offset;
+   uint32_t address_table_offset, symbol_table_offset, constant_pool_offset;
+   unsigned int cu_list_elements, tu_list_elements;
+-  unsigned int address_table_size, symbol_table_slots;
++  unsigned int address_table_elements, symbol_table_slots;
+   unsigned char *cu_list, *tu_list;
+   unsigned char *address_table, *symbol_table, *constant_pool;
+   unsigned int i;
+@@ -10511,48 +10511,19 @@ display_gdb_index (struct dwarf_section *section,
+       || tu_list_offset > section->size
+       || address_table_offset > section->size
+       || symbol_table_offset > section->size
+-      || constant_pool_offset > section->size)
++      || constant_pool_offset > section->size
++      || tu_list_offset < cu_list_offset
++      || address_table_offset < tu_list_offset
++      || symbol_table_offset < address_table_offset
++      || constant_pool_offset < symbol_table_offset)
+     {
+       warn (_("Corrupt header in the %s section.\n"), section->name);
+       return 0;
+     }
+ 
+-  /* PR 17531: file: 418d0a8a.  */
+-  if (tu_list_offset < cu_list_offset)
+-    {
+-      warn (_("TU offset (%x) is less than CU offset (%x)\n"),
+-	    tu_list_offset, cu_list_offset);
+-      return 0;
+-    }
+-
+-  cu_list_elements = (tu_list_offset - cu_list_offset) / 8;
+-
+-  if (address_table_offset < tu_list_offset)
+-    {
+-      warn (_("Address table offset (%x) is less than TU offset (%x)\n"),
+-	    address_table_offset, tu_list_offset);
+-      return 0;
+-    }
+-
+-  tu_list_elements = (address_table_offset - tu_list_offset) / 8;
+-
+-  /* PR 17531: file: 18a47d3d.  */
+-  if (symbol_table_offset < address_table_offset)
+-    {
+-      warn (_("Symbol table offset (%x) is less then Address table offset (%x)\n"),
+-	    symbol_table_offset, address_table_offset);
+-      return 0;
+-    }
+-
+-  address_table_size = symbol_table_offset - address_table_offset;
+-
+-  if (constant_pool_offset < symbol_table_offset)
+-    {
+-      warn (_("Constant pool offset (%x) is less than symbol table offset (%x)\n"),
+-	    constant_pool_offset, symbol_table_offset);
+-      return 0;
+-    }
+-
++  cu_list_elements = (tu_list_offset - cu_list_offset) / 16;
++  tu_list_elements = (address_table_offset - tu_list_offset) / 24;
++  address_table_elements = (symbol_table_offset - address_table_offset) / 20;
+   symbol_table_slots = (constant_pool_offset - symbol_table_offset) / 8;
+ 
+   cu_list = start + cu_list_offset;
+@@ -10561,31 +10532,25 @@ display_gdb_index (struct dwarf_section *section,
+   symbol_table = start + symbol_table_offset;
+   constant_pool = start + constant_pool_offset;
+ 
+-  if (address_table_offset + address_table_size > section->size)
+-    {
+-      warn (_("Address table extends beyond end of section.\n"));
+-      return 0;
+-    }
+-
+   printf (_("\nCU table:\n"));
+-  for (i = 0; i < cu_list_elements; i += 2)
++  for (i = 0; i < cu_list_elements; i++)
+     {
+-      uint64_t cu_offset = byte_get_little_endian (cu_list + i * 8, 8);
+-      uint64_t cu_length = byte_get_little_endian (cu_list + i * 8 + 8, 8);
++      uint64_t cu_offset = byte_get_little_endian (cu_list + i * 16, 8);
++      uint64_t cu_length = byte_get_little_endian (cu_list + i * 16 + 8, 8);
+ 
+-      printf (_("[%3u] 0x%lx - 0x%lx\n"), i / 2,
++      printf (_("[%3u] 0x%lx - 0x%lx\n"), i,
+ 	      (unsigned long) cu_offset,
+ 	      (unsigned long) (cu_offset + cu_length - 1));
+     }
+ 
+   printf (_("\nTU table:\n"));
+-  for (i = 0; i < tu_list_elements; i += 3)
++  for (i = 0; i < tu_list_elements; i++)
+     {
+-      uint64_t tu_offset = byte_get_little_endian (tu_list + i * 8, 8);
+-      uint64_t type_offset = byte_get_little_endian (tu_list + i * 8 + 8, 8);
+-      uint64_t signature = byte_get_little_endian (tu_list + i * 8 + 16, 8);
++      uint64_t tu_offset = byte_get_little_endian (tu_list + i * 24, 8);
++      uint64_t type_offset = byte_get_little_endian (tu_list + i * 24 + 8, 8);
++      uint64_t signature = byte_get_little_endian (tu_list + i * 24 + 16, 8);
+ 
+-      printf (_("[%3u] 0x%lx 0x%lx "), i / 3,
++      printf (_("[%3u] 0x%lx 0x%lx "), i,
+ 	      (unsigned long) tu_offset,
+ 	      (unsigned long) type_offset);
+       print_dwarf_vma (signature, 8);
+@@ -10593,12 +10558,11 @@ display_gdb_index (struct dwarf_section *section,
+     }
+ 
+   printf (_("\nAddress table:\n"));
+-  for (i = 0; i < address_table_size && i <= address_table_size - (2 * 8 + 4);
+-       i += 2 * 8 + 4)
++  for (i = 0; i < address_table_elements; i++)
+     {
+-      uint64_t low = byte_get_little_endian (address_table + i, 8);
+-      uint64_t high = byte_get_little_endian (address_table + i + 8, 8);
+-      uint32_t cu_index = byte_get_little_endian (address_table + i + 16, 4);
++      uint64_t low = byte_get_little_endian (address_table + i * 20, 8);
++      uint64_t high = byte_get_little_endian (address_table + i * 20 + 8, 8);
++      uint32_t cu_index = byte_get_little_endian (address_table + i + 20 + 16, 4);
+ 
+       print_dwarf_vma (low, 8);
+       print_dwarf_vma (high, 8);

--- a/meta/recipes-devtools/binutils/binutils/0029-CVE-2022-45703-2.patch
+++ b/meta/recipes-devtools/binutils/binutils/0029-CVE-2022-45703-2.patch
@@ -1,0 +1,31 @@
+From 37a35dc3c13957a55d83350a28279a9ea4218648 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Fri, 18 Nov 2022 11:29:13 +1030
+Subject: [PATCH] PR29799 heap buffer overflow in display_gdb_index
+ dwarf.c:10548
+
+	PR 29799
+	* dwarf.c (display_gdb_index): Typo fix.
+
+Upstream-Status: Backport [https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=69bfd1759db41c8d369f9dcc98a135c5a5d97299]
+
+CVE: CVE-2022-45703
+
+Signed-off-by: Chaitanya Vadrevu <chaitanya.vadrevu@ni.com>
+---
+ binutils/dwarf.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/binutils/dwarf.c b/binutils/dwarf.c
+index 5e802ac78cd..a6a33b29c80 100644
+--- a/binutils/dwarf.c
++++ b/binutils/dwarf.c
+@@ -10562,7 +10562,7 @@ display_gdb_index (struct dwarf_section *section,
+     {
+       uint64_t low = byte_get_little_endian (address_table + i * 20, 8);
+       uint64_t high = byte_get_little_endian (address_table + i * 20 + 8, 8);
+-      uint32_t cu_index = byte_get_little_endian (address_table + i + 20 + 16, 4);
++      uint32_t cu_index = byte_get_little_endian (address_table + i * 20 + 16, 4);
+ 
+       print_dwarf_vma (low, 8);
+       print_dwarf_vma (high, 8);


### PR DESCRIPTION
Patched following CVEs in binutils by backporting fixes from binutils upstream
- CVE-2022-44840
- CVE-2022-47695
- CVE-2022-45703

Marked following CVEs as patched by adding relevant CVE# to existing patch files
- CVE-2022-47673
- CVE-2022-47696

WI: [2517356](https://dev.azure.com/ni/DevCentral/_workitems/edit/2517356)

### Testing
- [x] `bitbake binutils` with `INHERIT += "cve-check"` added to my `local.conf`
- [x] `tmp-glibc/work/core2-64-nilrt-linux/binutils/2.38-r0/temp/cve.log` shows all these CVEs as patched.
- [x] cRIO-9049 and a VM boot with a BSI built with these changes.
- [x] Ran some binutils utilities such as `objdump`, `strings`, `readelf`, `size`, `nm` without issues.

### Note to maintainers
Please don't merge as I want to upstream first.