### PR TITLE
go: Fix issue in DNS resolver

### DIFF
--- a/meta/recipes-devtools/go/go-1.17.13.inc
+++ b/meta/recipes-devtools/go/go-1.17.13.inc
@@ -16,6 +16,7 @@ SRC_URI += "\
     file://0009-Revert-cmd-go-make-sure-CC-and-CXX-are-absolute.patch \
     file://0001-exec.go-do-not-write-linker-flags-into-buildids.patch \
     file://0001-src-cmd-dist-buildgo.go-do-not-hardcode-host-compile.patch \
+    file://0010-net-Fix-issue-with-DNS-not-being-updated.patch  \
     file://CVE-2022-27664.patch \
     file://0001-net-http-httputil-avoid-query-parameter-smuggling.patch \
     file://CVE-2022-41715.patch \

--- a/meta/recipes-devtools/go/go-1.20/0010-net-Fix-issue-with-DNS-not-being-updated.patch
+++ b/meta/recipes-devtools/go/go-1.20/0010-net-Fix-issue-with-DNS-not-being-updated.patch
@@ -1,0 +1,51 @@
+From 20176b390e28daa86b4552965cb7bd9181983c4d Mon Sep 17 00:00:00 2001
+From: Chaitanya Vadrevu <chaitanya.vadrevu@ni.com>
+Date: Mon, 6 Nov 2023 20:11:19 -0600
+Subject: [PATCH] net: Fix issue with DNS not being updated
+
+When dns requests are made, go's native DNS resolver only reads
+/etc/resolv.conf if the previous request is older than 5 seconds.
+
+On first network call, an initialization code runs that is
+supposed to initialize DNS data and set lastChecked time. There is a bug
+in this code that causes /etc/resolv.conf to not be read during
+initialization and the DNS data from program startup ends up being used
+until the next 5 seconds. This means that if /etc/resolv.conf changed
+between program startup and the first network call, old DNS data is
+still used until the next 5 seconds.
+
+This causes "docker pull" to fail the first time if docker daemon is
+started before networking is up.
+
+Upstream commit d52883f443e1d564b0300acdd382af1769bf0477 made lot of
+improvements to DNS resolver to fix some issues which also fixes this
+issue.
+This patch picks the relevant changes from it to fix this particular
+issue.
+
+Upstream-Status: Backport [https://github.com/golang/go/commit/d52883f443e1d564b0300acdd382af1769bf0477]
+
+Signed-off-by: Chaitanya Vadrevu <chaitanya.vadrevu@ni.com>
+---
+ src/net/dnsclient_unix.go | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/src/net/dnsclient_unix.go b/src/net/dnsclient_unix.go
+index 6dfd4af..520ffe6 100644
+--- a/src/net/dnsclient_unix.go
++++ b/src/net/dnsclient_unix.go
+@@ -337,10 +337,7 @@ var resolvConf resolverConfig
+ func (conf *resolverConfig) init() {
+ 	// Set dnsConfig and lastChecked so we don't parse
+ 	// resolv.conf twice the first time.
+-	conf.dnsConfig = systemConf().resolv
+-	if conf.dnsConfig == nil {
+-		conf.dnsConfig = dnsReadConfig("/etc/resolv.conf")
+-	}
++	conf.dnsConfig = dnsReadConfig("/etc/resolv.conf")
+ 	conf.lastChecked = time.Now()
+ 
+ 	// Prepare ch so that only one update of resolverConfig may
+-- 
+2.34.1
+


### PR DESCRIPTION
This change adds a patch that is a partial backport of an upstream
commit[1].

It fixes a bug in go's DNS resolver that was causing a docker issue
where the first "docker pull" always fails after system boot if docker
daemon is started before networking is completely up.

[1] https://github.com/golang/go/commit/d52883f443e1d564b0300acdd382af1769bf0477

AB: [2564155](https://dev.azure.com/ni/DevCentral/_workitems/edit/2564155/)

### Testing
- [x] `bitbake docker-ce`
- [x] Installed `docker-ce` ipk on a VM and verified that `docker pull` no longer fails after system boot.

### Note
~~This PR is RFC~~. I intend to submit this upstream and if it gets accepted, get the fix into our repo via upstream merge.
Update: We decided to merge this without waiting for upstream to accept it.

Note to anyone doing upstream merge in future: If upstream accepts this and we see a merge conflict due to this on next upstream merge, please revert this commit and run the merge again to get these changes from upstream.