### PR TITLE
[next] create-spdx: skip spdx processing for uncontrolled packages

### DIFF
--- a/meta/classes/create-spdx-2.2.bbclass
+++ b/meta/classes/create-spdx-2.2.bbclass
@@ -1031,17 +1031,16 @@ def combine_spdx(d, rootfs_name, rootfs_deploydir, rootfs_spdxid, packages, spdx
 
     for name in sorted(packages.keys()):
         if name not in providers:
+            if d.getVar("BUILD_IMAGES_FROM_FEEDS") == "1":
+                bb.warn(f"Skipping SPDX combination for package {name}.")
+                continue
             bb.fatal("Unable to find SPDX provider for '%s'" % name)
 
         pkg_name, pkg_hashfn = providers[name]
 
         pkg_spdx_path = oe.sbom.doc_find_by_hashfn(deploy_dir_spdx, package_archs, pkg_name, pkg_hashfn)
         if not pkg_spdx_path:
-            if d.getVar('BUILD_IMAGES_FROM_FEEDS') == "1":
-                bb.warn("spdx: %s has no spdx available. Skipping." % name)
-                continue
-            else:
-                bb.fatal("No SPDX file found for package %s, %s" % (pkg_name, pkg_hashfn))
+            bb.fatal("No SPDX file found for package %s, %s" % (pkg_name, pkg_hashfn))
 
         pkg_doc, pkg_doc_sha1 = oe.sbom.read_doc(pkg_spdx_path)
 


### PR DESCRIPTION
When building images from feeds, some packages are not controlled by OE. In these cases, we need to skip attempting to process their SPDX artifacts - which do not exist.

[AB#2467374](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2467374)

# Testing
* [x] With this change, the create-spdx step of building the core images no longer fails.