### PR TITLE
opkg-keyrings: mark architecture as all

### DIFF
--- a/meta/recipes-devtools/opkg/opkg-keyrings_1.0.bb
+++ b/meta/recipes-devtools/opkg/opkg-keyrings_1.0.bb
@@ -2,6 +2,8 @@ SUMMARY = "Keyrings for verifying opkg packages and feeds"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
+inherit allarch
+
 # Distro-specific keys can be added to this package in two ways:
 #
 #   1) In a .bbappend, add .gpg and/or .asc files to SRC_URI and install them to


### PR DESCRIPTION
### Summary of Changes

The PR changes the architecture of the opkg-keyrings IPK so that it is marked with the all-arch.


### Justification

[#AB2346871](https://dev.azure.com/ni/DevCentral/_workitems/edit/2346871)

NILRT deployments which are very old might conceivably outlive the lifetimes of their default opkg signing keys. Eg. a NILRT 20.0 deployment with only the 2019 signing key may be deployed in 2029. NI doesn't provide an appealing user interface to manipulate the opkg keystore. But we should give customers a pathway to upgrade their signing keys which is more easy than hacking newer OE feeds onto their device.

As part of this, there will be some changes made to opkg-keyrings IPK. This PR is a follow-up to [!739](https://github.com/ni/meta-nilrt/pull/739).
The current PR marks the package as all-arch, since the IPK is marked as being architecture-specific by default, even though it contains entirely cross-platform content like the keyrings themselves.

### Testing
Tested that the IPK is built under deploy/ipk/all.
![image](https://github.com/user-attachments/assets/e04ee915-2f3a-4796-b81b-1b26b14a5a8d)

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).


Signed-off by: Pratheeksha S N <pratheeksha.s.n@ni.com>