### PR TITLE
xorg-font-common: Install fonts after target boots

### DIFF
--- a/meta/recipes-graphics/xorg-font/xorg-font-common.inc
+++ b/meta/recipes-graphics/xorg-font/xorg-font-common.inc
@@ -30,7 +30,7 @@ do_install:append() {
 FILES:${PN} += " ${libdir}/X11/fonts ${datadir}"
 
 PACKAGE_WRITE_DEPS += "mkfontdir-native mkfontscale-native"
-pkg_postinst:${PN} () {
+pkg_postisnt_ontarget:${PN} () {
         for fontdir in `find $D/usr/lib/X11/fonts -type d`; do
                 mkfontdir $fontdir
                 mkfontscale $fontdir


### PR DESCRIPTION
Our base system image build have been throwing multiple warnings about fonts not being able to find configuration files. I believe this is because the build requires access to files, such as the font cache, that are present on the target. Updating the font postinst recipe to run on the target resolves the warnings. The related tech debt item is here: https://dev.azure.com/ni/DevCentral/_workitems/edit/2812142

# Testing
Built locally and confirmed there were no font warnings.