### PR TITLE
xorg-font-common: Remove references to lib/X11/fonts

### DIFF
--- a/meta/recipes-graphics/xorg-font/xorg-font-common.inc
+++ b/meta/recipes-graphics/xorg-font/xorg-font-common.inc
@@ -21,8 +21,6 @@ REQUIRED_DISTRO_FEATURES = "x11"
 EXTRA_OEMAKE += "FCCACHE=/bin/true UTIL_DIR=${STAGING_DIR_TARGET}\$\(MAPFILES_PATH\)"
 
 do_install:append() {
-	find ${D}${libdir}/X11/fonts -type f -name fonts.dir | xargs rm -f
-	find ${D}${libdir}/X11/fonts -type f -name fonts.scale | xargs rm -f
 	find ${D}${datadir}/fonts/X11 -type f -name fonts.dir | xargs rm -f
 	find ${D}${datadir}/fonts/X11 -type f -name fonts.scale | xargs rm -f	
 }
@@ -30,11 +28,7 @@ do_install:append() {
 FILES:${PN} += " ${libdir}/X11/fonts ${datadir}"
 
 PACKAGE_WRITE_DEPS += "mkfontdir-native mkfontscale-native"
-pkg_postisnt_ontarget:${PN} () {
-        for fontdir in `find $D/usr/lib/X11/fonts -type d`; do
-                mkfontdir $fontdir
-                mkfontscale $fontdir
-        done
+pkg_postisnt:${PN} () {
         for fontdir in `find $D/usr/share/fonts/X11 -type d`; do
                 mkfontdir $fontdir
                 mkfontscale $fontdir


### PR DESCRIPTION
The font warnings and "No such file or directory" errors are all related to /usr/lib/X11/fonts. It doesn't look like this directory is being successfully created. This change removes it and reverts the previous ontarget workaround.