### PR TITLE
Revert "xorg-font-common: Install fonts after target boots"

### DIFF
--- a/meta/recipes-graphics/xorg-font/xorg-font-common.inc
+++ b/meta/recipes-graphics/xorg-font/xorg-font-common.inc
@@ -30,7 +30,7 @@ do_install:append() {
 FILES:${PN} += " ${libdir}/X11/fonts ${datadir}"
 
 PACKAGE_WRITE_DEPS += "mkfontdir-native mkfontscale-native"
-pkg_postisnt_ontarget:${PN} () {
+pkg_postinst:${PN} () {
         for fontdir in `find $D/usr/lib/X11/fonts -type d`; do
                 mkfontdir $fontdir
                 mkfontscale $fontdir


### PR DESCRIPTION
This change causes problems for read-only rootfs and does not fully resolve the font issues. Upstream is also aware of the issue.

This reverts commit 59775d62f5b9313d2e0569768e0ac467aae8e9ea.