### PR TITLE
jitterentropy-rngd: Update override syntax and SPDX license name

### DIFF
--- a/meta/recipes-support/jitterentropy/jitterentropy-rngd_1.0.8.bb
+++ b/meta/recipes-support/jitterentropy/jitterentropy-rngd_1.0.8.bb
@@ -8,7 +8,7 @@ Especially during boot time, when the entropy of Linux is low, the Jitter RNGd \
 provides a source of sufficient entropy."
 HOMEPAGE = "http://www.chronox.de/jent.html"
 
-LICENSE = "GPLv2+ | BSD"
+LICENSE = "GPL-2.0-or-later | BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=e52365752b36cfcd7f9601d80de7d8c6 \
                     file://COPYING.bsd;md5=66a5cedaf62c4b2637025f049f9b826f \
                     file://COPYING.gplv2;md5=eb723b61539feef013de476e68b5c50a \
@@ -35,10 +35,10 @@ do_install () {
 	install -m 0755 ${WORKDIR}/init-jitterentropy-rngd ${D}${sysconfdir}/init.d/jitterentropy-rngd
 }
 
-INSANE_SKIP_${PN} += "already-stripped"
+INSANE_SKIP:${PN} += "already-stripped"
 
 INITSCRIPT_NAME = "jitterentropy-rngd"
 INITSCRIPT_PARAMS = "start 3 S . stop 1 0 6 ."
 
-SYSTEMD_SERVICE_${PN} = "jitterentropy.service"
+SYSTEMD_SERVICE:${PN} = "jitterentropy.service"
 


### PR DESCRIPTION
Building jitterentropy-rngd results in QA issues:
```
ERROR: jitterentropy-rngd-1.0+gitAUTOINC+23be1542a2-r0 do_package: QA Issue: File '/usr/sbin/jitterentropy-rngd' from jitterentropy-rngd was already stripped, this will prevent future debugging! [already-stripped]
ERROR: jitterentropy-rngd-1.0+gitAUTOINC+23be1542a2-r0 do_package: Fatal QA errors were found, failing task.
```

Turns out the old override syntax for `INSANE_SKIP` fails quietly, so the check still proceeds. 

Also convert to use SPDX license names in LICENSE variables, otherwise the build complains about it:
```
WARNING: jitterentropy-rngd-1.0+gitAUTOINC+23be1542a2-r0 do_package: QA Issue: jitterentropy-rngd: No generic license file exists for: BSD in any provider [license-exists]
WARNING: jitterentropy-rngd-1.0+gitAUTOINC+23be1542a2-r0 do_package_qa: QA Issue: Recipe LICENSE includes obsolete licenses GPLv2+ [obsolete-license]
```