### PR TITLE
ptest-packagelists: add run-postinsts

### DIFF
--- a/meta/conf/distro/include/ptest-packagelists.inc
+++ b/meta/conf/distro/include/ptest-packagelists.inc
@@ -74,6 +74,7 @@ PTESTS_FAST = "\
     python3-webcolors \
     qemu \
     quilt \
+    run-postinsts \
     sed \
     slang \
     wayland \


### PR DESCRIPTION
Fixes the "supports ptests but is not included in oe-core's ptest-packagelists.inc [missing-ptest]" warning for run-postinsts by adding it to ptest-packagelists.inc.

AB#[2951033](https://dev.azure.com/ni/DevCentral/_workitems/edit/2951033)
### Testing

- [X] Built the packagefeed-ni-core recipe without any warnings.