### PR TITLE
kernel-devsrc: make tools/Build optional

### DIFF
--- a/meta/recipes-kernel/linux/kernel-devsrc.bb
+++ b/meta/recipes-kernel/linux/kernel-devsrc.bb
@@ -156,7 +156,7 @@ do_install() {
             # these are a few files associated with objtool, since we'll need to
             # rebuild it
             cp -a --parents tools/build/Build.include $kerneldir/build/
-            cp -a --parents tools/build/Build $kerneldir/build/
+            cp -a --parents tools/build/Build $kerneldir/build/ 2>/dev/null || :
             cp -a --parents tools/build/fixdep.c $kerneldir/build/
             cp -a --parents tools/scripts/utilities.mak $kerneldir/build/
 


### PR DESCRIPTION
Cherry-picked commit 13e16e5be25f379211c7329fa1462464174c0f2d from upstream master to fix build issue for 6.12 kernel.

WI: [AB#2951013](https://dev.azure.com/ni/DevCentral/_workitems/edit/2951013)

### Testing
- [x] Built `packagefeed-ni-core`, `nilrt-base-system-image`, `packagegroup-ni-next-kernel` with 6.12 kernel changes in meta-nilrt
- [x] Boot tested on a VM and cRIO-9049
- [x] Verified `packagegroup-ni-next-kernel` is installable and bootable
- [x] Verified that ni-kal could be installed/reversioned on 6.12 kernel