### PR TITLE
kernel-devsrc.bb: Replace extra System.map file with symlink

### DIFF
--- a/meta/recipes-kernel/linux/kernel-devsrc.bb
+++ b/meta/recipes-kernel/linux/kernel-devsrc.bb
@@ -75,7 +75,8 @@ do_install() {
         if [ -s Module.symvers ]; then
             cp Module.symvers $kerneldir/build
         fi
-        cp System.map* $kerneldir/build
+        cp System.map-* $kerneldir/build
+        ln -s System.map-* $kerneldir/build/System.map
         if [ -s Module.markers ]; then
             cp Module.markers $kerneldir/build
         fi


### PR DESCRIPTION
Cherry-pick [cc971fffb134aa6af9edeabb7a5f4143dee2151e](https://git.openembedded.org/openembedded-core/commit/meta/recipes-kernel/linux/kernel-devsrc.bb?id=cc971fffb134aa6af9edeabb7a5f4143dee2151e) from the openembedded-core master branch to resolve [AB#3112870](https://dev.azure.com/ni/DevCentral/_workitems/edit/3112870)

Currently there are two .map files being copied to $kerneldir/build. One of the files is System.map and the other is
System.map-<kernel version>. Each .map file takes up about 5MB and have identical sha256sum hashes. This change will make it so only System.map-<kernel version> is copied in order to save disk space. It also recreates System.map as a symlink to that .map file.