### PR TITLE
Add support to build scarthgap BSI FIT image for ARM

### DIFF
--- a/meta/classes-recipe/kernel-fitimage.bbclass
+++ b/meta/classes-recipe/kernel-fitimage.bbclass
@@ -391,7 +391,11 @@ fitimage_emit_section_config() {
 	# conf node name is selected based on dtb ID if it is present,
 	# otherwise its selected based on kernel ID
 	if [ -n "$dtb_image" ]; then
-		conf_node=$conf_node$dtb_image
+		# DeviceCode in uboot env for NI devices is of format 0x76D6.
+		# And since bootscript.txt can't remove '0x' from DeviceCode before
+		# calling bootm, change FDT configuration node instead to add '0x'.
+		conf_node_dtb_image_name=ni-0x${dtb_image#*-}
+		conf_node=$conf_node$conf_node_dtb_image_name
 	else
 		conf_node=$conf_node$kernel_id
 	fi

--- a/meta/classes-recipe/kernel-fitimage.bbclass
+++ b/meta/classes-recipe/kernel-fitimage.bbclass
@@ -210,7 +210,7 @@ fitimage_emit_section_boot_script() {
 	bootscr_sign_keyname="${UBOOT_SIGN_IMG_KEYNAME}"
 
         cat << EOF >> $1
-                bootscr-$2 {
+                bootscript@$2 {
                         description = "U-boot script";
                         data = /incbin/("$3");
                         type = "script";


### PR DESCRIPTION
### Summary of Changes

Added changes to support building ARM BSI FIT image.

### Justification

WI: [AB#3217134](https://dev.azure.com/ni/DevCentral/_workitems/edit/3217134)

### Testing

- [x] `bitbake packagefeed-ni-core` on ARM scarthgap
- [x] `bitbake packagegroup-ni-desirable` on ARM scarthgap
- [x] `bitbake nilrt-base-system-image` on ARM scarthgap