### PR TITLE
spdx: Update spdx to include 'Ignored' CVEs

### DIFF
--- a/meta/classes/create-spdx-2.2.bbclass
+++ b/meta/classes/create-spdx-2.2.bbclass
@@ -605,6 +605,16 @@ python do_create_spdx() {
     if patched_cves:
         recipe.sourceInfo = "CVEs fixed: " + patched_cves
 
+    ignored_cves = oe.cve_check.get_ignored_cves(d)
+    ignored_cves = list(ignored_cves)
+    ignored_cves = ' '.join(ignored_cves)
+    if ignored_cves:
+        if patched_cves:
+            recipe.sourceInfo += "; "
+        else:
+            recipe.sourceInfo = ""
+        recipe.sourceInfo += "CVEs ignored: " + ignored_cves
+
     cpe_ids = oe.cve_check.get_cpe_ids(d.getVar("CVE_PRODUCT"), d.getVar("CVE_VERSION"))
     if cpe_ids:
         for cpe_id in cpe_ids:

--- a/meta/lib/oe/cve_check.py
+++ b/meta/lib/oe/cve_check.py
@@ -140,6 +140,19 @@ def get_patched_cves(d):
     return patched_cves
 
 
+def get_ignored_cves(d):
+    """
+    Get CVEs that are marked as ignored using the "CVE_STATUS" flag.
+    """
+    ignored_cves = set()
+    for cve in (d.getVarFlags("CVE_STATUS") or {}):
+        decoded_status, _, _ = decode_cve_status(d, cve)
+        if decoded_status == "Ignored":
+            bb.debug(2, "CVE %s is ignored" % cve)
+            ignored_cves.add(cve)
+    return ignored_cves
+
+
 def get_cpe_ids(cve_product, version):
     """
     Get list of CPE identifiers for the given product and version


### PR DESCRIPTION
### Summary of Changes
Updated spdx to include "Ignored CVEs"

### Justification
WI: [AB#3363035](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3363035)

### Testing
- [x] `bitbake packagefeed-ni-core`
- [x] `bitbake nilrt-safemode-rootfs`
- [x] `bitbake nilrt-base-system-image`
- [x] Verified recipes-xf.spdx.json contains "CVEs ignored..."

### Note to Reviewers
There is no goal to upstream this change is only needed for internal SBOM requirements