### PR TITLE
base-files: Fix .profile and .bashrc install paths

### DIFF
--- a/meta/recipes-core/base-files/base-files_3.0.14.bb
+++ b/meta/recipes-core/base-files/base-files_3.0.14.bb
@@ -111,8 +111,8 @@ do_install () {
 
 	ln -sf /proc/mounts ${D}${sysconfdir}/mtab
 
-	install -m 0644 ${WORKDIR}/share/dot.profile ${D}${ROOT_HOME}/.profile
-	install -m 0644 ${WORKDIR}/share/dot.bashrc ${D}${ROOT_HOME}/.bashrc
+	install -m 0644 ${S}/share/dot.profile ${D}${ROOT_HOME}/.profile
+	install -m 0644 ${S}/share/dot.bashrc ${D}${ROOT_HOME}/.bashrc
 
 	# deal with hostname
 	if [ "${hostname}" ]; then


### PR DESCRIPTION
**Summary of Changes**
Updated recipe that previously accessed source files via ${WORKDIR} to instead use ${S}.
This issue was causing build errors because the .profile and .bashrc dotfiles could not be found when installing.
This fixes an issue introduced in the cherry-picked [commit](https://github.com/ni/openembedded-core/pull/171/commits/70c236b1e310cf9775ca5b650bdf864b3a7e84fd)
, where these lines were missed.

**Testing**
None — path correction only, no functional changes.
