### PR TITLE
create-spdx: Init sourceInfo to empty string

### DIFF
--- a/meta/classes/create-spdx-2.2.bbclass
+++ b/meta/classes/create-spdx-2.2.bbclass
@@ -599,6 +599,7 @@ python do_create_spdx() {
     # Some CVEs may be patched during the build process without incrementing the version number,
     # so querying for CVEs based on the CPE id can lead to false positives. To account for this,
     # save the CVEs fixed by patches to source information field in the SPDX.
+    recipe.sourceInfo = ""
     patched_cves = oe.cve_check.get_patched_cves(d)
     patched_cves = list(patched_cves)
     patched_cves = ' '.join(patched_cves)
@@ -611,9 +612,8 @@ python do_create_spdx() {
     if ignored_cves:
         if patched_cves:
             recipe.sourceInfo += "; "
-        else:
-            recipe.sourceInfo = ""
         recipe.sourceInfo += "CVEs ignored: " + ignored_cves
+
 
     cpe_ids = oe.cve_check.get_cpe_ids(d.getVar("CVE_PRODUCT"), d.getVar("CVE_VERSION"))
     if cpe_ids:


### PR DESCRIPTION
### Summary
`do_create_spdx` not populating sourceInfo for ignored or patched CVEs set by `CVE_STATUS` when not properly initialized.

### Testing
- [x] Built `apache2` and verified spdx contains sourceInfo of "ignored" CVEs
- [x] Built `zstd` and verified spdx contains "empty" sourceInfo