### PR TITLE
SPDX: Remove obsolete 2.2 skip logic and add skip handling for SPDX 3.0

### DIFF
--- a/meta/classes/create-spdx-2.2.bbclass
+++ b/meta/classes/create-spdx-2.2.bbclass
@@ -849,11 +849,7 @@ def combine_spdx(d, rootfs_name, rootfs_deploydir, rootfs_spdxid, packages, spdx
 
             pkg_spdx_path = oe.sbom.doc_find_by_hashfn(deploy_dir_spdx, package_archs, pkg_name, pkg_hashfn)
             if not pkg_spdx_path:
-                if d.getVar('BUILD_IMAGES_FROM_FEEDS') == "1":
-                    bb.warn("spdx: %s has no spdx available. Skipping." % name)
-                    continue
-                else:
-                    bb.fatal("No SPDX file found for package %s, %s" % (pkg_name, pkg_hashfn))
+                bb.fatal("No SPDX file found for package %s, %s" % (pkg_name, pkg_hashfn))
 
             pkg_doc, pkg_doc_sha1 = oe.sbom.read_doc(pkg_spdx_path)
 

--- a/meta/classes/create-spdx-2.2.bbclass
+++ b/meta/classes/create-spdx-2.2.bbclass
@@ -843,16 +843,17 @@ def combine_spdx(d, rootfs_name, rootfs_deploydir, rootfs_spdxid, packages, spdx
     if packages:
         for name in sorted(packages.keys()):
             if name not in providers:
-                if d.getVar("BUILD_IMAGES_FROM_FEEDS") == "1":
-                    bb.warn(f"Skipping SPDX combination for package {name}.")
-                    continue
                 bb.fatal("Unable to find SPDX provider for '%s'" % name)
 
             pkg_name, pkg_hashfn = providers[name]
 
             pkg_spdx_path = oe.sbom.doc_find_by_hashfn(deploy_dir_spdx, package_archs, pkg_name, pkg_hashfn)
             if not pkg_spdx_path:
-                bb.fatal("No SPDX file found for package %s, %s" % (pkg_name, pkg_hashfn))
+                if d.getVar('BUILD_IMAGES_FROM_FEEDS') == "1":
+                    bb.warn("spdx: %s has no spdx available. Skipping." % name)
+                    continue
+                else:
+                    bb.fatal("No SPDX file found for package %s, %s" % (pkg_name, pkg_hashfn))
 
             pkg_doc, pkg_doc_sha1 = oe.sbom.read_doc(pkg_spdx_path)
 

--- a/meta/lib/oe/spdx30_tasks.py
+++ b/meta/lib/oe/spdx30_tasks.py
@@ -1029,9 +1029,13 @@ def collect_build_package_inputs(d, objset, build, packages, files_by_hash=None)
                 files_by_hash.setdefault(h, set()).update(f)
 
     if missing_providers:
-        bb.fatal(
-            f"Unable to find SPDX provider(s) for: {', '.join(sorted(missing_providers))}"
-        )
+        if d.getVar("BUILD_IMAGES_FROM_FEEDS") == "1":
+            for p in sorted(missing_providers):
+                bb.warn(f"Skipping SPDX provider for package {p}.")
+        else:
+            bb.fatal(
+                f"Unable to find SPDX provider(s) for: {', '.join(sorted(missing_providers))}"
+            )
 
     if build_deps:
         objset.new_scoped_relationship(


### PR DESCRIPTION
**Summary of Changes**

The default SPDX version used by create-spdx has been updated to [SPDX 3.0](https://github.com/ni/openembedded-core/blob/16775cd95e287df203e41867be0b05f4e63492ee/meta/classes/create-spdx.bbclass#L8C9-L8C24). As a result, the previous skip logic implemented for SPDX 2.2 is no longer required.

1. Reverts the 2 earlier commits that skipped SPDX processing for uncontrolled packages when using SPDX 2.2, as it is no longer needed.
- create-spdx: Skip missing files when building from feeds. - [commit](https://github.com/ni/openembedded-core/commit/37ac5f97ff23de2bbc73756b954436d5c00e87c6)
- create-spdx: skip spdx processing for uncontrolled packages - [commit](https://github.com/ni/openembedded-core/commit/2a874e8cc74383363131703837de0e50109eb1cb)

2. Adds updated logic to skip SPDX processing for uncontrolled packages when generating SPDX 3.0 artifacts, preventing build errors for feed-sourced packages.

**Testing**
`do_create_rootfs_spdx` now  passes successfully.