### PR TITLE
cve-check: Skip ni packages during image cve_check

### DIFF
--- a/meta/classes/cve-check.bbclass
+++ b/meta/classes/cve-check.bbclass
@@ -237,7 +237,16 @@ python cve_check_write_rootfs_manifest () {
     for pkg in list(image_list_installed_packages(d)):
         pkg_info = os.path.join(d.getVar('PKGDATA_DIR'),
                                 'runtime-reverse', pkg)
+
+        if not os.path.exists(pkg_info):
+            # This occurs for packages that are created and built via nibuild
+            bb.warn("cve_check_write_rootfs_manifest: Skipping for package " +
+                os.path.basename(pkg_info)
+            )
+            continue
+
         pkg_data = oe.packagedata.read_pkgdatafile(pkg_info)
+
         recipies.add(pkg_data["PN"])
 
     bb.note("Writing rootfs CVE manifest")


### PR DESCRIPTION
### Summary
nibuild packages causes failures when building images with `cve-check` enabled, due to these packages not providing pkg_info files.

### Justification
Enabling `cve-check` for images will allow for CVEs defined via `CVE_STATUS` to be propagated to `spdx`. This will then be reflected to dependency tracker

### Testing
- [x] Built `nilrt-safemode-rootfs`
- [x] Built `nilrt-base-system-image` and verified spdx contains `CVE_STATUS` CVEs