### PR TITLE
Temporarily pin SPDX 2.2 and restore feed-based handling

### DIFF
--- a/meta/classes/create-spdx-2.2.bbclass
+++ b/meta/classes/create-spdx-2.2.bbclass
@@ -849,7 +849,11 @@ def combine_spdx(d, rootfs_name, rootfs_deploydir, rootfs_spdxid, packages, spdx
 
             pkg_spdx_path = oe.sbom.doc_find_by_hashfn(deploy_dir_spdx, package_archs, pkg_name, pkg_hashfn)
             if not pkg_spdx_path:
-                bb.fatal("No SPDX file found for package %s, %s" % (pkg_name, pkg_hashfn))
+                if d.getVar('BUILD_IMAGES_FROM_FEEDS') == "1":
+                    bb.warn("spdx: %s has no spdx available. Skipping." % name)
+                    continue
+                else:
+                    bb.fatal("No SPDX file found for package %s, %s" % (pkg_name, pkg_hashfn))
 
             pkg_doc, pkg_doc_sha1 = oe.sbom.read_doc(pkg_spdx_path)
 

--- a/meta/classes/create-spdx-2.2.bbclass
+++ b/meta/classes/create-spdx-2.2.bbclass
@@ -843,17 +843,16 @@ def combine_spdx(d, rootfs_name, rootfs_deploydir, rootfs_spdxid, packages, spdx
     if packages:
         for name in sorted(packages.keys()):
             if name not in providers:
+                if d.getVar("BUILD_IMAGES_FROM_FEEDS") == "1":
+                    bb.warn(f"Skipping SPDX combination for package {name}.")
+                    continue
                 bb.fatal("Unable to find SPDX provider for '%s'" % name)
 
             pkg_name, pkg_hashfn = providers[name]
 
             pkg_spdx_path = oe.sbom.doc_find_by_hashfn(deploy_dir_spdx, package_archs, pkg_name, pkg_hashfn)
             if not pkg_spdx_path:
-                if d.getVar('BUILD_IMAGES_FROM_FEEDS') == "1":
-                    bb.warn("spdx: %s has no spdx available. Skipping." % name)
-                    continue
-                else:
-                    bb.fatal("No SPDX file found for package %s, %s" % (pkg_name, pkg_hashfn))
+                bb.fatal("No SPDX file found for package %s, %s" % (pkg_name, pkg_hashfn))
 
             pkg_doc, pkg_doc_sha1 = oe.sbom.read_doc(pkg_spdx_path)
 

--- a/meta/classes/create-spdx.bbclass
+++ b/meta/classes/create-spdx.bbclass
@@ -5,4 +5,4 @@
 #
 # Include this class when you don't care what version of SPDX you get; it will
 # be updated to the latest stable version that is supported
-inherit create-spdx-3.0
+inherit create-spdx-2.2


### PR DESCRIPTION
### Summary

This PR temporarily pins SPDX to 2.2 and restores legacy feed-based SPDX handling by applying the reverted commits that were reverted as after SPDX Version change that became obsolete.(fyi: [PR](https://github.com/ni/openembedded-core/pull/178)). The change prevents feed-based image build failures while downstream consumers remain incompatible with SPDX 3.0.

**NOTE**: I am not reverting the patch that I added for SPDX 3.0 version to skip the NI packages processing as that does not effect the current scenario and later when we will update the SPDX version to 3.0 version so it will be needed.

([For more context](https://dev.azure.com/ni/DevCentral/_git/ni-central/pullRequest/1143089#1768235209))

### Justification
[AB#3039672](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3039672)

Tech Debt: [AB#3707566](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3707566)

### Testing

- [x] Verified that all images were build successfully.
- [x] Verified that `.spdx.tar.zst` files were produced for the all images.
