### PR TITLE
go-native: Mark CVEs as fixed-version

### DIFF
--- a/meta/recipes-devtools/go/go-binary-native_1.22.12.bb
+++ b/meta/recipes-devtools/go/go-binary-native_1.22.12.bb
@@ -19,6 +19,12 @@ UPSTREAM_CHECK_REGEX = "go(?P<pver>\d+(\.\d+)+)\.linux"
 CVE_PRODUCT = "golang:go"
 CVE_STATUS[CVE-2024-3566] = "not-applicable-platform: Issue only applies on Windows"
 CVE_STATUS[CVE-2025-0913] = "not-applicable-platform: Issue only applies on Windows"
+CVE_STATUS[CVE-2025-4674] = "fixed-version: Binary used only for bootstrap; actual go compiler built from source includes fix"
+CVE_STATUS[CVE-2025-47907] = "fixed-version: Binary used only for bootstrap; actual go compiler built from source includes fix"
+CVE_STATUS[CVE-2025-58187] = "fixed-version: Binary used only for bootstrap; actual go compiler built from source includes fix"
+CVE_STATUS[CVE-2025-58188] = "fixed-version: Binary used only for bootstrap; actual go compiler built from source includes fix"
+CVE_STATUS[CVE-2025-61723] = "fixed-version: Binary used only for bootstrap; actual go compiler built from source includes fix"
+CVE_STATUS[CVE-2025-61729] = "fixed-version: Binary used only for bootstrap; actual go compiler built from source includes fix"
 
 S = "${WORKDIR}/go"
 


### PR DESCRIPTION

`CVE-2025-4674`, `CVE-2025-47907`, `CVE-2025-58187`, `CVE-2025-58188`, `CVE-2025-61723` and `CVE-2025-61729` were flagged for "go-binary-native". Upon investigation, these CVEs do not apply to the -native.

[AB#3732115](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3732115)