### PR TITLE
ovmf: support TPM2 functionality

### DIFF
--- a/meta/recipes-core/ovmf/ovmf_git.bb
+++ b/meta/recipes-core/ovmf/ovmf_git.bb
@@ -11,9 +11,10 @@ LIC_FILES_CHKSUM = "file://OvmfPkg/License.txt;md5=06357ddc23f46577c2aeaeaf7b776
 # may change that default.
 PACKAGECONFIG ??= ""
 PACKAGECONFIG += "${@bb.utils.contains('MACHINE_FEATURES', 'tpm', 'tpm', '', d)}"
-PACKAGECONFIG += "${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'tpm', '', d)}"
+PACKAGECONFIG += "${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'tpm2', '', d)}"
 PACKAGECONFIG[secureboot] = ",,,"
 PACKAGECONFIG[tpm] = "-D TPM_ENABLE=TRUE,-D TPM_ENABLE=FALSE,,"
+PACKAGECONFIG[tpm2] = "-D TPM2_ENABLE=TRUE, -D TPM2_ENABLE=FALSE,,"
 
 # GCC12 trips on it
 #see https://src.fedoraproject.org/rpms/edk2/blob/rawhide/f/0032-Basetools-turn-off-gcc12-warning.patch


### PR DESCRIPTION
TPM2 support is added to the EDK2 compilation using the TPM2_ENABLED config value. Assert this config value when 'tpm2' is in the MACHINE_FEATURES.

This patchset is necessary for us to generate OVMF UEFI firmware images that we can use in our NILRT QEMU machines to dev/test secure boot and measured boot with virtualized TPM2 devices.

This patch will get sent upstream and I will then cherry-pick it back into scarthgap.