### PR TITLE
ovmf: support TPM2 functionality

### DIFF
--- a/meta/recipes-core/ovmf/ovmf_git.bb
+++ b/meta/recipes-core/ovmf/ovmf_git.bb
@@ -11,9 +11,10 @@ LIC_FILES_CHKSUM = "file://OvmfPkg/License.txt;md5=06357ddc23f46577c2aeaeaf7b776
 # may change that default.
 PACKAGECONFIG ??= ""
 PACKAGECONFIG += "${@bb.utils.contains('MACHINE_FEATURES', 'tpm', 'tpm', '', d)}"
-PACKAGECONFIG += "${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'tpm', '', d)}"
+PACKAGECONFIG += "${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'tpm tpm2', '', d)}"
 PACKAGECONFIG[secureboot] = ",,,"
 PACKAGECONFIG[tpm] = "-D TPM_ENABLE=TRUE,-D TPM_ENABLE=FALSE,,"
+PACKAGECONFIG[tpm2] = "-D TPM2_ENABLE=TRUE, -D TPM2_ENABLE=FALSE,,"
 
 # GCC12 trips on it
 #see https://src.fedoraproject.org/rpms/edk2/blob/rawhide/f/0032-Basetools-turn-off-gcc12-warning.patch


### PR DESCRIPTION
# Changes

This patchset adds the config options necessary to build the `ovmf` UEFI firmware recipe with TPM2 support, when `tpm2` is in the distro MACHINEFEATURES.


# Testing

* [x] Built and used this firmware to make a NILRT QEMU VM with an attached TPM2 and confirmed that the UEFI firmware writes boot measurements into the TPM PCRs.


# Process

* The original version of this commit will go to upstream OE-core master, but it would never be cherry picked to scarthgap. So this is the scarthgap version that should go into our fork now.