### PR TITLE
Add support to build next BSI FIT image for ARM

### DIFF
--- a/meta/classes-recipe/kernel-fit-image.bbclass
+++ b/meta/classes-recipe/kernel-fit-image.bbclass
@@ -110,7 +110,7 @@ python do_compile() {
     # Prepare a u-boot script section
     fit_uboot_env = d.getVar("FIT_UBOOT_ENV")
     if fit_uboot_env:
-        root_node.fitimage_emit_section_boot_script("bootscr-"+fit_uboot_env , fit_uboot_env)
+        root_node.fitimage_emit_section_boot_script("bootscript@"+fit_uboot_env , fit_uboot_env)
 
     # Prepare a setup section (For x86)
     setup_bin_path = os.path.join(kernel_deploydir, "setup.bin")

--- a/meta/lib/oe/fitimage.py
+++ b/meta/lib/oe/fitimage.py
@@ -487,6 +487,10 @@ class ItsNodeRootKernel(ItsNode):
                 dtb_name = dtb.name
                 if dtb.name.startswith("fdt-"):
                     dtb_name = dtb.name[len("fdt-"):]
+                # DeviceCode in uboot env for NI devices is of format 0x76D6.
+                # And since bootscript.txt can't remove '0x' from DeviceCode before
+                # calling bootm, change FDT configuration node instead to add '0x'.
+                dtb_name = dtb_name.replace("ni-", "ni-0x")
 
                 dtb_renamed = dtb_name
                 if dtb_name in dtb_confs:

--- a/meta/recipes-bsp/u-boot/u-boot.inc
+++ b/meta/recipes-bsp/u-boot/u-boot.inc
@@ -65,9 +65,15 @@ do_compile () {
         uboot_compile
     fi
 
-    if [ -n "${UBOOT_ENV}" ] && [ "${UBOOT_ENV_SUFFIX}" = "scr" ]
+    if [ -n "${UBOOT_ENV}" ]
     then
-        ${UBOOT_MKIMAGE} -C none -A ${UBOOT_ARCH} -T script -d ${UNPACKDIR}/${UBOOT_ENV_SRC} ${B}/${UBOOT_ENV_BINARY}
+        if [ "${UBOOT_ENV_SUFFIX}" = "scr" ]
+        then
+            ${UBOOT_MKIMAGE} -C none -A ${UBOOT_ARCH} -T script -d ${UNPACKDIR}/${UBOOT_ENV_SRC} ${B}/${UBOOT_ENV_BINARY}
+        elif [ "${UBOOT_ENV_SUFFIX}" = "txt" ]
+        then
+            install -m 644 ${UNPACKDIR}/${UBOOT_ENV_BINARY} ${B}/${UBOOT_ENV_BINARY}
+        fi
     fi
 }
 

--- a/meta/recipes-support/jitterentropy/jitterentropy-rngd_1.0.8.bb
+++ b/meta/recipes-support/jitterentropy/jitterentropy-rngd_1.0.8.bb
@@ -22,8 +22,6 @@ SRC_URI = "git://github.com/smuellerDD/jitterentropy-rngd.git;protocol=https;bra
 PV = "1.0+git${SRCPV}"
 SRCREV = "23be1542a232aefb33a1efa8bc5eef017f2ae261"
 
-S = "${WORKDIR}/git"
-
 inherit update-rc.d systemd
 
 do_install () {
@@ -32,7 +30,7 @@ do_install () {
 			UNITDIR="${systemd_unitdir}"
 
 	install -d ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/init-jitterentropy-rngd ${D}${sysconfdir}/init.d/jitterentropy-rngd
+	install -m 0755 ${UNPACKDIR}/init-jitterentropy-rngd ${D}${sysconfdir}/init.d/jitterentropy-rngd
 }
 
 INSANE_SKIP:${PN} += "already-stripped"


### PR DESCRIPTION
### Summary of Changes
Added changes to support building ARM BSI FIT image.
Also fixed a trivial build issue w.r.t WORKDIR that had to be renamed to UNPACKDIR for jitterentropy recipe.

### Justification

[AB#3711980](https://dev.azure.com/ni/DevCentral/_workitems/edit/3711980/)

### Testing

- [x]  bitbake packagefeed-ni-core on ARM next
- [x]  bitbake nilrt-base-system-image on ARM next
- [x] Tested the changes on NI-cRIO 9147 and NI-cRIO 9068 arm targets by copying the BSI tar file into the target and installing it.

Resulting linux_runmode.itb dump:

<img width="468" height="635" alt="image" src="https://github.com/user-attachments/assets/23e5c566-42c4-430f-a104-9507b6af0ae3" />

### Note

Dependent PR: https://github.com/ni/meta-nilrt/pull/989
