### PR TITLE
kernel-fitimage: Add NI specific variables to FIT image

### DIFF
--- a/meta/classes-recipe/kernel-fitimage.bbclass
+++ b/meta/classes-recipe/kernel-fitimage.bbclass
@@ -64,6 +64,9 @@ fitimage_emit_fit_header() {
 / {
         description = "${FIT_DESC}";
         #address-cells = <${FIT_ADDRESS_CELLS}>;
+        version = "${FIT_VERSION}";
+        DeviceCode = "${FIT_DEVICECODE}";
+        DeviceCodes = "${FIT_DEVICECODES}";
 EOF
 }
 


### PR DESCRIPTION
version, DeviceCode, DeviceCodes are expected to be present in FIT by firmware upgrade scripts.

Upstream-Status: Inappropriate [NI specific]

WI: [AB#3221312](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3221312)

### Testing
- [x] `bitbake linux-nilrt-arm-safemode` with these changes and verified FIT contains the variables.
- [x] cRIO-9068 firmware can be upgraded from 26.3 to the one built with this and https://github.com/ni/meta-nilrt/pull/991.