### PR TITLE
create-spdx: Inject versionInfo into download packages

### DIFF
--- a/meta/classes/create-spdx-2.2.bbclass
+++ b/meta/classes/create-spdx-2.2.bbclass
@@ -473,6 +473,7 @@ def add_download_packages(d, doc, recipe):
                     package.checksums.append(c)
 
             package.downloadLocation = uri
+            package.versionInfo = d.getVar("PV")
             doc.packages.append(package)
             doc.add_relationship(doc, "DESCRIBES", package)
             # In the future, we might be able to do more fancy dependencies,


### PR DESCRIPTION
### Summary of Changes
Updated create-spdx.bbclass to include `versionInfo` for downloaded remote packages

### Justification
[AB#3814753](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3814753)

### Testing
- [x] bitbake `packagefeed-ni-core` with `INHERIT += "cve-check"` enabled
- [x] bitbake `nilrt-safemode-rootfs` with `INHERIT += "cve-check"` enabled
- [x] bitbake `nilrt-base-system-image` with `INHERIT += "cve-check"` enabled
- [x] Verified generated SPDX files contain versionInfo