### PR TITLE
Cherry-pick commits needed to build 6.18 kernels in scarthgap

### DIFF
--- a/meta/recipes-kernel/kern-tools/kern-tools-native_git.bb
+++ b/meta/recipes-kernel/kern-tools/kern-tools-native_git.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "\
 
 DEPENDS += "git-replacement-native"
 
-SRCREV = "7160ebe8b865dd6028aef278efa219433db93f7e"
+SRCREV = "f589e1df23251d8319063da0a61c1016b2a0bf85"
 PV = "0.3+git"
 
 inherit native

--- a/meta/recipes-kernel/linux/kernel-devsrc.bb
+++ b/meta/recipes-kernel/linux/kernel-devsrc.bb
@@ -318,6 +318,16 @@ do_install() {
         cp -a --parents kernel/time/timeconst.bc $kerneldir/build 2>/dev/null || :
         cp -a --parents kernel/bounds.c $kerneldir/build 2>/dev/null || :
 
+        # v6.18+ rq offset generation needs these scheduler sources/headers
+        cp -a --parents kernel/sched/rq-offsets.c $kerneldir/build 2>/dev/null || :
+        cp -a --parents kernel/sched/sched.h $kerneldir/build 2>/dev/null || :
+        cp -a --parents kernel/sched/cpudeadline.h $kerneldir/build 2>/dev/null || :
+        cp -a --parents kernel/sched/cpupri.h $kerneldir/build 2>/dev/null || :
+        cp -a --parents kernel/sched/features.h $kerneldir/build 2>/dev/null || :
+        cp -a --parents kernel/sched/stats.h $kerneldir/build 2>/dev/null || :
+        cp -a --parents kernel/sched/ext.h $kerneldir/build 2>/dev/null || :
+        cp -a --parents kernel/workqueue_internal.h $kerneldir/build 2>/dev/null || :
+
         if [ "${ARCH}" = "mips" ]; then
             cp -a --parents arch/mips/Kbuild.platforms $kerneldir/build/
             cp --parents $(find -type f -name "Platform") $kerneldir/build

--- a/meta/recipes-kernel/linux/kernel-devsrc.bb
+++ b/meta/recipes-kernel/linux/kernel-devsrc.bb
@@ -285,6 +285,7 @@ do_install() {
             cp -a --parents arch/x86/tools/relocs_common.c $kerneldir/build/
             cp -a --parents arch/x86/tools/relocs.h $kerneldir/build/
             cp -a --parents arch/x86/tools/gen-insn-attr-x86.awk $kerneldir/build/ 2>/dev/null || :
+            cp -a --parents arch/x86/tools/cpufeaturemasks.awk $kerneldir/build/ 2>/dev/null || :
             cp -a --parents arch/x86/purgatory/purgatory.c $kerneldir/build/
 
             # 4.18 + have unified the purgatory files, so we ignore any errors if


### PR DESCRIPTION
### Summary of Changes

Cherry-pick the minimal set of kernel devsrc and tools commits needed to enable 6.18 kernel builds in scarthgap.

### Justification

[AB#3599949](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3599949)

### Testing

* [x] `bitbake virtual/kernel`
* [x] `bitbake linux-nilrt-next`
* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] `bitbake -k packagefeed-ni-extra`. All kernel related packages built successfully

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).